### PR TITLE
Add documentation translation workflows and configs

### DIFF
--- a/.github/workflows/destroy-deployment.yml
+++ b/.github/workflows/destroy-deployment.yml
@@ -1,0 +1,24 @@
+name: Destroy-deployments
+
+on:
+  pull_request:
+    paths:
+      - 'doc/**/*'
+    types:
+      - closed
+jobs:
+  destroy-deployment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Set branch name from source branch
+        run: echo "BRANCH_NAME=${GITHUB_HEAD_REF##*/}" >> $GITHUB_ENV
+
+      - name: Remove dev server deployment at ${{env.DEPLOYMENT_NAME}}
+        uses: strumwolf/delete-deployment-environment@v2
+        with:
+          token: "${{ secrets.TARANTOOLBOT_TOKEN }}"
+          environment: "translation-${{env.BRANCH_NAME}}"

--- a/.github/workflows/pull-translation.yml
+++ b/.github/workflows/pull-translation.yml
@@ -1,0 +1,51 @@
+name: Pull translations
+
+on:
+  workflow_dispatch:
+    branches:
+      - '!master'
+jobs:
+  pull-translations:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{secrets.TARANTOOLBOT_TOKEN}}
+
+      - name: Set branch name from source branch
+        run: echo "BRANCH_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
+      - name: Setup Python environment
+        uses: actions/setup-python@v2
+
+      - name: Setup Python requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r doc/requirements.txt
+
+      - name: Pull translations from Crowdin
+        uses: crowdin/github-action@1.0.21
+        with:
+          config: 'doc/crowdin.yaml'
+          upload_sources: false
+          upload_translations: false
+          push_translations: false
+          download_translations: true
+          download_language: 'ru'
+          crowdin_branch_name: ${{env.BRANCH_NAME}}
+          debug_mode: true
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          CROWDIN_PERSONAL_TOKEN: ${{secrets.CROWDIN_PERSONAL_TOKEN}}
+
+      - name: Cleanup translation files
+        run: |
+          sudo chown -R runner:docker doc/locale/ru/LC_MESSAGES
+          python doc/cleanup.py po
+
+      - name: Commit translation files
+        uses: stefanzweifel/git-auto-commit-action@v4.1.2
+        with:
+          commit_message: "Update translations"
+          file_pattern: "*.po"

--- a/.github/workflows/push-translation.yml
+++ b/.github/workflows/push-translation.yml
@@ -1,0 +1,55 @@
+name: Push translation sources
+
+on:
+  pull_request:
+    paths:
+      - 'doc/**/*'
+jobs:
+  push-translation-sources:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set branch name from source branch
+        run: echo "BRANCH_NAME=${GITHUB_HEAD_REF##*/}" >> $GITHUB_ENV
+
+      - name: Start translation service deployment
+        uses: bobheadxi/deployments@v0.5.2
+        id: translation
+        with:
+          step: start
+          token: ${{secrets.GITHUB_TOKEN}}
+          env: translation-${{env.BRANCH_NAME}}
+          ref: ${{github.head_ref}}
+
+      - name: Setup Python environment
+        uses: actions/setup-python@v2
+
+      - name: Setup Python requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r doc/requirements.txt
+
+      - name: Build pot files
+        run: python -m sphinx . doc/locale/en -c doc -b gettext
+
+      - name: Push POT files to crowdin
+        uses: crowdin/github-action@1.0.21
+        with:
+          upload_sources: true
+          upload_translations: false
+          crowdin_branch_name: ${{env.BRANCH_NAME}}
+          config: 'doc/crowdin.yaml'
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          CROWDIN_PERSONAL_TOKEN: ${{secrets.CROWDIN_PERSONAL_TOKEN}}
+
+      - name: update deployment status
+        uses: bobheadxi/deployments@v0.5.2
+        with:
+          step: finish
+          token: ${{secrets.GITHUB_TOKEN}}
+          status: ${{job.status}}
+          deployment_id: ${{steps.translation.outputs.deployment_id}}
+          env_url: https://crowdin.com/project/tarantool-cpp/ru#/${{env.BRANCH_NAME}}

--- a/.github/workflows/upload-translations.yml
+++ b/.github/workflows/upload-translations.yml
@@ -1,0 +1,38 @@
+name: Update translations on the main branch
+
+on:
+  push:
+    paths:
+      - 'doc/**/*'
+    branches:
+      - master
+jobs:
+  autocommit-pot-files:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup Python environment
+      uses: actions/setup-python@v2
+
+    - name: Setup Python requirements
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r doc/requirements.txt
+
+    - name: Build pot files
+      run: python -m sphinx . doc/locale/en -c doc -b gettext
+
+    - name: Push Pot-files to crowdin
+      uses: crowdin/github-action@1.1.0
+      with:
+        config: 'doc/crowdin.yaml'
+        upload_sources: true
+        upload_translations: true
+        import_eq_suggestions: true
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        CROWDIN_PERSONAL_TOKEN: ${{secrets.CROWDIN_PERSONAL_TOKEN}}

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@
 *.exe
 *.out
 *.app
+
+# Documentation builds
+doc/locale/en/
+doc/output

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,20 @@
+[![Crowdin](https://badges.crowdin.net/tarantool-cpp/localized.svg)](https://crowdin.com)
+
+# Tarantool Tarantool C++ Connector documentation
+Part of Tarantool documentation, published to 
+https://www.tarantool.io/en/doc/latest/getting_started/getting_started_cxx/
+
+### Create pot files from rst
+```bash
+python -m sphinx . doc/locale/en -c doc -b gettext
+```
+
+### Create/update po from pot files
+```bash
+sphinx-intl update -p doc/locale/en -d doc/locale -l ru
+```
+
+### Build documentation to doc/output
+```bash
+python -m sphinx . doc/output -c doc
+```

--- a/doc/cleanup.py
+++ b/doc/cleanup.py
@@ -1,0 +1,46 @@
+#! /usr/bin/env python3
+import argparse
+from glob import glob
+from polib import pofile, POFile, _BaseFile
+
+parser = argparse.ArgumentParser(description='Cleanup PO and POT files')
+parser.add_argument('extension', type=str, choices=['po', 'pot', 'both'],
+                    help='cleanup files with extension: po, pot or both')
+
+
+class PoFile(POFile):
+
+    def __unicode__(self):
+        return _BaseFile.__unicode__(self)
+
+    def metadata_as_entry(self):
+        class M:
+            def __unicode__(self, _):
+                return ''
+        return M()
+
+
+def cleanup_files(extension):
+    mask = f'**/*.{extension}'
+    for file_path in glob(mask, recursive=True):
+        print(f'cleanup {file_path}')
+        po_file: POFile = pofile(file_path, klass=PoFile)
+        po_file.header = ''
+        po_file.metadata = {}
+        po_file.metadata_is_fuzzy = False
+
+        for item in po_file:
+            item.occurrences = None
+
+        po_file.save()
+
+
+if __name__ == "__main__":
+
+    args = parser.parse_args()
+
+    if args.extension in ['po', 'both']:
+        cleanup_files('po')
+
+    if args.extension in ['pot', 'both']:
+        cleanup_files('pot')

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,23 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(''))
+
+master_doc = 'doc/tntcxx_getting_started'
+
+source_suffix = '.rst'
+
+project = u'tntcxx'
+
+exclude_patterns = [
+    'doc/locale',
+    'doc/output',
+    'doc/README.md',
+    'doc/cleanup.py',
+    'doc/requirements.txt',
+]
+
+language = 'en'
+locale_dirs = ['./doc/locale']
+gettext_compact = False
+gettext_location = True

--- a/doc/crowdin.yaml
+++ b/doc/crowdin.yaml
@@ -1,0 +1,24 @@
+# https://support.crowdin.com/configuration-file/
+# https://support.crowdin.com/cli-tool-v3/#configuration
+
+"project_id" : "457586"
+"base_path" : "doc/locale"
+"base_url": "https://crowdin.com"
+"api_token_env": "CROWDIN_PERSONAL_TOKEN"
+
+
+"preserve_hierarchy": true
+
+files: [
+ {
+  "source" : "/en/**/*.pot",
+  "translation" : "/%locale_with_underscore%/LC_MESSAGES/**/%file_name%.po",
+  "update_option" : "update_as_unapproved",
+
+  "languages_mapping" : {
+    "locale_with_underscore" : {
+      "ru" : "ru",
+     }
+  },
+ }
+]

--- a/doc/locale/ru/LC_MESSAGES/doc/tntcxx_api.po
+++ b/doc/locale/ru/LC_MESSAGES/doc/tntcxx_api.po
@@ -1,0 +1,565 @@
+
+msgid "C++ connector API"
+msgstr ""
+
+msgid ""
+"The official C++ connector for Tarantool is located in the `tanartool/tntcxx"
+" <https://github.com/tarantool/tntcxx/>`_ repository."
+msgstr ""
+
+msgid ""
+"It is not supplied as part of the Tarantool repository and requires "
+"additional actions for usage. The connector itself is a header-only library "
+"and, as such, doesn't require installation and building. All you need is to "
+"clone the connector source code and embed it in your C++ project. See the "
+":doc:`C++ connector Getting started </getting_started/getting_started_cxx>` "
+"document for details and examples."
+msgstr ""
+
+msgid "Below is the description of the connector public API."
+msgstr ""
+
+msgid "Connector class"
+msgstr ""
+
+msgid ""
+"The ``Connector`` class is a template class that defines a connector client "
+"which can handle many connections to Tarantool instances asynchronously."
+msgstr ""
+
+msgid ""
+"To instantiate a client, you should specify the buffer and the network "
+"provider implementations as template parameters. You can either implement "
+"your own buffer or network provider or use the default ones."
+msgstr ""
+
+msgid "The default connector instantiation looks as follows:"
+msgstr ""
+
+msgid "Public methods"
+msgstr ""
+
+msgid ":ref:`connect() <tntcxx_api_connector_connect>`"
+msgstr ""
+
+msgid ":ref:`wait() <tntcxx_api_connector_wait>`"
+msgstr ""
+
+msgid ":ref:`waitAll() <tntcxx_api_connector_waitall>`"
+msgstr ""
+
+msgid ":ref:`waitAny() <tntcxx_api_connector_waitany>`"
+msgstr ""
+
+msgid ":ref:`close() <tntcxx_api_connector_close>`"
+msgstr ""
+
+msgid ""
+"Connects to a Tarantool instance that is listening on ``addr:port``. On "
+"successful connection, the method returns ``0``. If the host doesn't reply "
+"within the timeout period or another error occurs, it returns ``-1``. Then, "
+":ref:`Connection.getError() <tntcxx_api_connection_geterror>` gives the "
+"error message."
+msgstr ""
+
+msgid "Parameters"
+msgstr ""
+
+msgid "object of the :ref:`Connection <tntcxx_api_connection>` class."
+msgstr ""
+
+msgid "address of the host where a Tarantool instance is running."
+msgstr ""
+
+msgid "port that a Tarantool instance is listening on."
+msgstr ""
+
+msgid "connection timeout, seconds. Optional. Defaults to ``2``."
+msgstr ""
+
+msgid "Returns"
+msgstr ""
+
+msgid "``0`` on success, or ``-1`` otherwise."
+msgstr ""
+
+msgid "rtype"
+msgstr ""
+
+msgid "int"
+msgstr ""
+
+msgid "**Possible errors:**"
+msgstr ""
+
+msgid "connection timeout"
+msgstr ""
+
+msgid "refused to connect (due to incorrect address or/and port)"
+msgstr ""
+
+msgid ""
+"system errors: a socket can't be created; failure of any of the system calls"
+" (``fcntl``, ``select``, ``send``, ``receive``)."
+msgstr ""
+
+msgid "**Example:**"
+msgstr ""
+
+msgid ""
+"The main method responsible for sending a request and checking the response "
+"readiness."
+msgstr ""
+
+msgid ""
+"You should prepare a request beforehand by using the necessary method of the"
+" :ref:`Connection <tntcxx_api_connection>` class, such as :ref:`ping() "
+"<tntcxx_api_connection_ping>` and so on, which encodes the request in the "
+"`MessagePack <https://msgpack.org/>`_ format and saves it in the output "
+"connection buffer."
+msgstr ""
+
+msgid ""
+"``wait()`` sends the request and is polling the ``future`` for the response "
+"readiness. Once the response is ready, ``wait()`` returns ``0``. If at "
+"``timeout`` the response isn't ready or another error occurs, it returns "
+"``-1``. Then, :ref:`Connection.getError() <tntcxx_api_connection_geterror>` "
+"gives the error message. ``timeout = 0`` means the method is polling the "
+"``future`` until the response is ready."
+msgstr ""
+
+msgid ""
+"request ID returned by a request method of the :ref:`Connection "
+"<tntcxx_api_connection>` class, such as, :ref:`ping() "
+"<tntcxx_api_connection_ping>` and so on."
+msgstr ""
+
+msgid "waiting timeout, milliseconds. Optional. Defaults to ``0``."
+msgstr ""
+
+msgid "``0`` on receiving a response, or ``-1`` otherwise."
+msgstr ""
+
+msgid "timeout exceeded"
+msgstr ""
+
+msgid ""
+"other possible errors depend on a network provider used. If the "
+"``DefaultNetProvider`` is used, failing of the ``poll``, ``read``, and "
+"``write`` system calls leads to system errors, such as, ``EBADF``, "
+"``ENOTSOCK``, ``EFAULT``, ``EINVAL``, ``EPIPE``, and ``ENOTCONN`` "
+"(``EWOULDBLOCK`` and ``EAGAIN`` don't occur in this case)."
+msgstr ""
+
+msgid ""
+"Similar to :ref:`wait() <tntcxx_api_connector_wait>`, the method sends the "
+"requests prepared and checks the response readiness, but can send several "
+"different requests stored in the ``futures`` array. Exceeding the timeout "
+"leads to an error; :ref:`Connection.getError() "
+"<tntcxx_api_connection_geterror>` gives the error message. ``timeout = 0`` "
+"means the method is polling the ``futures`` until all the responses are "
+"ready."
+msgstr ""
+
+msgid ""
+"array with the request IDs returned by request methods of the "
+":ref:`Connection <tntcxx_api_connection>` class, such as, :ref:`ping() "
+"<tntcxx_api_connection_ping>` and so on."
+msgstr ""
+
+msgid "size of the ``futures`` array."
+msgstr ""
+
+msgid "none"
+msgstr ""
+
+msgid ""
+"Sends all requests that are prepared at the moment and is waiting for any "
+"first response to be ready. Upon the response readiness, ``waitAny()`` "
+"returns the corresponding connection object. If at ``timeout`` no response "
+"is ready or another error occurs, it returns ``nullptr``. Then, "
+":ref:`Connection.getError() <tntcxx_api_connection_geterror>` gives the "
+"error message. ``timeout = 0`` means no time limitation while waiting for "
+"the response readiness."
+msgstr ""
+
+msgid ""
+"object of the :ref:`Connection <tntcxx_api_connection>` class on success, or"
+" ``nullptr`` on error."
+msgstr ""
+
+msgid "Connection<BUFFER, NetProvider>*"
+msgstr ""
+
+msgid ""
+"Closes the connection established earlier by the :ref:`connect() "
+"<tntcxx_api_connector_connect>` method."
+msgstr ""
+
+msgid ""
+"connection object of the :ref:`Connection <tntcxx_api_connection>` class."
+msgstr ""
+
+msgid "**Possible errors:** none."
+msgstr ""
+
+msgid "Connection class"
+msgstr ""
+
+msgid ""
+"The ``Connection`` class is a template class that defines a connection "
+"objects which is required to interact with a Tarantool instance. Each "
+"connection object is bound to a single socket."
+msgstr ""
+
+msgid ""
+"Similar to a :ref:`connector client <tntcxx_api_connector>`, a connection "
+"object also takes the buffer and the network provider as template "
+"parameters, and they must be the same as ones of the client. For example:"
+msgstr ""
+
+msgid ""
+"The ``Connection`` class has two nested classes, namely, :ref:`Space "
+"<tntcxx_api_connection_space>` and :ref:`Index "
+"<tntcxx_api_connection_index>` that implement the data-manipulation methods "
+"like ``select()``, ``replace()``, and so on."
+msgstr ""
+
+msgid "Public types"
+msgstr ""
+
+msgid ""
+"The alias of the built-in ``size_t`` type. ``rid_t`` is used for entities "
+"that return or contain a request ID."
+msgstr ""
+
+msgid ":ref:`call() <tntcxx_api_connection_call>`"
+msgstr ""
+
+msgid ":ref:`futureIsReady() <tntcxx_api_connection_futureisready>`"
+msgstr ""
+
+msgid ":ref:`getResponse() <tntcxx_api_connection_getresponse>`"
+msgstr ""
+
+msgid ":ref:`getError() <tntcxx_api_connection_geterror>`"
+msgstr ""
+
+msgid ":ref:`reset() <tntcxx_api_connection_reset>`"
+msgstr ""
+
+msgid ":ref:`ping() <tntcxx_api_connection_ping>`"
+msgstr ""
+
+msgid ""
+"Executes a call of a remote stored-procedure similar to :ref:`conn:call() "
+"<net_box-call>`. The method returns the request ID that is used to get the "
+"response by :ref:`getResponse() <tntcxx_api_connection_getresponse>`."
+msgstr ""
+
+msgid "a remote stored-procedure name."
+msgstr ""
+
+msgid "procedure's arguments."
+msgstr ""
+
+msgid "a request ID"
+msgstr ""
+
+msgid "rid_t"
+msgstr ""
+
+msgid ""
+"The following function is defined on the Tarantool instance you are "
+"connected to:"
+msgstr ""
+
+msgid "The function call can look as follows:"
+msgstr ""
+
+msgid ""
+"Checks availability of a request ID (``future``) returned by any of the "
+"request methods, such as, :ref:`ping() <tntcxx_api_connection_ping>` and so "
+"on."
+msgstr ""
+
+msgid ""
+"``futureIsReady()`` returns ``true`` if the ``future`` is available or "
+"``false`` otherwise."
+msgstr ""
+
+msgid "a request ID."
+msgstr ""
+
+msgid "``true`` or ``false``"
+msgstr ""
+
+msgid "bool"
+msgstr ""
+
+msgid ""
+"The method takes a request ID (``future``) as an argument and returns an "
+"optional object containing a response. If the response is not ready, the "
+"method returns ``std::nullopt``. Note that for each ``future`` the method "
+"can be called only once because it erases the request ID from the internal "
+"map as soon as the response is returned to a user."
+msgstr ""
+
+msgid ""
+"A response consists of a header (``response.header``) and a body "
+"(``response.body``). Depending on success of the request execution on the "
+"server side, body may contain either runtime errors accessible by "
+"``response.body.error_stack`` or data (tuples) accessible by "
+"``response.body.data``. Data is a vector of tuples. However, tuples are not "
+"decoded and come in the form of pointers to the start and the end of "
+"MessagePacks. For details on decoding the data received, refer to "
+":ref:`\"Decoding and reading the data\" <gs_cxx_reader>`."
+msgstr ""
+
+msgid "a response object or ``std::nullopt``"
+msgstr ""
+
+msgid "std::optional<Response<BUFFER>>"
+msgstr ""
+
+msgid ""
+"Returns an error message for the last error occured during the execution of "
+"methods of the :ref:`Connector <tntcxx_api_connector>` and :ref:`Connection "
+"<tntcxx_api_connection>` classes."
+msgstr ""
+
+msgid "an error message"
+msgstr ""
+
+msgid "std::string&"
+msgstr ""
+
+msgid ""
+"Resets a connection after errors, that is, cleans up the error message and "
+"the connection status."
+msgstr ""
+
+msgid "Prepares a request to ping a Tarantool instance."
+msgstr ""
+
+msgid ""
+"The method encodes the request in the `MessagePack <https://msgpack.org/>`_ "
+"format and queues it in the output connection buffer to be sent later by one"
+" of :ref:`Connector's <tntcxx_api_connector>` methods, namely, :ref:`wait() "
+"<tntcxx_api_connector_wait>`, :ref:`waitAll() "
+"<tntcxx_api_connector_waitall>`, or :ref:`waitAny() "
+"<tntcxx_api_connector_waitany>`."
+msgstr ""
+
+msgid ""
+"Returns the request ID that is used to get the response by the "
+":ref:`getResponce() <tntcxx_api_connection_getresponse>` method."
+msgstr ""
+
+msgid "Nested classes and their methods"
+msgstr ""
+
+msgid ":ref:`Space <tntcxx_api_connection_space>`"
+msgstr ""
+
+msgid ":ref:`Index <tntcxx_api_connection_index>`"
+msgstr ""
+
+msgid "Space class"
+msgstr ""
+
+msgid ""
+"``Space`` is a nested class of the :ref:`Connection <tntcxx_api_connection>`"
+" class. It is a public wrapper to access the data-manipulation methods in "
+"the way similar to the Tarantool submodule "
+":doc:`box.space</reference/reference_lua/box_space>`, like, "
+"``space[space_id].select()``, ``space[space_id].replace()``, and so on."
+msgstr ""
+
+msgid ""
+"All the ``Space`` class methods listed below work in the following way:"
+msgstr ""
+
+msgid ""
+"A method encodes the corresponding request in the `MessagePack "
+"<https://msgpack.org/>`_ format and queues it in the output connection "
+"buffer to be sent later by one of :ref:`Connector's <tntcxx_api_connector>` "
+"methods, namely, :ref:`wait() <tntcxx_api_connector_wait>`, :ref:`waitAll() "
+"<tntcxx_api_connector_waitall>`, or :ref:`waitAny() "
+"<tntcxx_api_connector_waitany>`."
+msgstr ""
+
+msgid ""
+"A method returns the request ID. To get and read the actual data requested, "
+"first you need to get the response object by using the :ref:`getResponce() "
+"<tntcxx_api_connection_getresponse>` method and then :ref:`decode "
+"<gs_cxx_reader>` the data."
+msgstr ""
+
+msgid "**Public methods**:"
+msgstr ""
+
+msgid ":ref:`select() <tntcxx_api_connection_select>`"
+msgstr ""
+
+msgid ":ref:`replace() <tntcxx_api_connection_replace>`"
+msgstr ""
+
+msgid ":ref:`insert() <tntcxx_api_connection_insert>`"
+msgstr ""
+
+msgid ":ref:`update() <tntcxx_api_connection_update>`"
+msgstr ""
+
+msgid ":ref:`upsert() <tntcxx_api_connection_upsert>`"
+msgstr ""
+
+msgid ":ref:`delete_() <tntcxx_api_connection_delete>`"
+msgstr ""
+
+msgid ""
+"Searches for a tuple or a set of tuples in the given space. The method works"
+" similar to :doc:`/reference/reference_lua/box_space/select` and performs "
+"the search against the primary index (``index_id = 0``) by default. In other"
+" words, ``space[space_id].select()`` equals to "
+"``space[space_id].index[0].select()``."
+msgstr ""
+
+msgid "value to be matched against the index key."
+msgstr ""
+
+msgid "index ID. Optional. Defaults to ``0``."
+msgstr ""
+
+msgid ""
+"maximum number of tuples to select. Optional. Defaults to ``UINT32_MAX``."
+msgstr ""
+
+msgid "number of tuples to skip. Optional. Defaults to ``0``."
+msgstr ""
+
+msgid "the type of iterator. Optional. Defaults to ``EQ``."
+msgstr ""
+
+msgid ""
+"Inserts a tuple into the given space. If a tuple with the same primary key "
+"already exists, ``replace()`` replaces the existing tuple with a new one. "
+"The method works similar to "
+":doc:`/reference/reference_lua/box_space/replace`."
+msgstr ""
+
+msgid "a tuple to insert."
+msgstr ""
+
+msgid ""
+"Inserts a tuple into the given space. The method works similar to "
+":doc:`/reference/reference_lua/box_space/insert`."
+msgstr ""
+
+msgid ""
+"Updates a tuple in the given space. The method works similar to "
+":doc:`/reference/reference_lua/box_space/update` and searches for the tuple "
+"to update against the primary index (``index_id = 0``) by default. In other "
+"words, ``space[space_id].update()`` equals to "
+"``space[space_id].index[0].update()``."
+msgstr ""
+
+msgid ""
+"The ``tuple`` parameter specifies an update operation, an identifier of the "
+"field to update, and a new field value. The set of available operations and "
+"the format of specifying an operation and a field identifier is the same as "
+"in Tarantool. Refer to the description of :doc:` "
+"</reference/reference_lua/box_space/update>` and example below for details."
+msgstr ""
+
+msgid ""
+"parameters for the update operation, namely, ``operator, field_identifier, "
+"value``."
+msgstr ""
+
+msgid ""
+"Updates or inserts a tuple in the given space. The method works similar to "
+":doc:`/reference/reference_lua/box_space/upsert`."
+msgstr ""
+
+msgid ""
+"If there is an existing tuple that matches the key fields of ``tuple``, the "
+"request has the same effect as :ref:`update() "
+"<tntcxx_api_connection_update>` and the ``ops`` parameter is used. If there "
+"is no existing tuple that matches the key fields of ``tuple``, the request "
+"has the same effect as :ref:`insert() <tntcxx_api_connection_insert>` and "
+"the ``tuple`` parameter is used."
+msgstr ""
+
+msgid ""
+"starting number to count fields in a tuple: ``0`` or ``1``. Optional. "
+"Defaults to ``0``."
+msgstr ""
+
+msgid ""
+"Deletes a tuple in the given space. The method works similar to "
+":doc:`/reference/reference_lua/box_space/delete` and searches for the tuple "
+"to delete against the primary index (``index_id = 0``) by default. In other "
+"words, ``space[space_id].delete_()`` equals to "
+"``space[space_id].index[0].delete_()``."
+msgstr ""
+
+msgid "Index class"
+msgstr ""
+
+msgid ""
+"``Index`` is a nested class of the :ref:`Space "
+"<tntcxx_api_connection_space>` class. It is a public wrapper to access the "
+"data-manipulation methods in the way similar to the Tarantool submodule "
+":doc:`box.index </reference/reference_lua/box_index>`, like, "
+"``space[space_id].index[index_id].select()`` and so on."
+msgstr ""
+
+msgid ""
+"All the ``Index`` class methods listed below work in the following way:"
+msgstr ""
+
+msgid ""
+"A method returns the request ID that is used to get the response by the "
+":ref:`getResponce() <tntcxx_api_connection_getresponse>` method. Refer to "
+"the :ref:`getResponce() <tntcxx_api_connection_getresponse>` description to "
+"understand the response structure and how to read the requested data."
+msgstr ""
+
+msgid ":ref:`select() <tntcxx_api_connection_select_i>`"
+msgstr ""
+
+msgid ":ref:`update() <tntcxx_api_connection_update_i>`"
+msgstr ""
+
+msgid ":ref:`delete_() <tntcxx_api_connection_delete_i>`"
+msgstr ""
+
+msgid ""
+"This is an alternative to :ref:`space.select() "
+"<tntcxx_api_connection_select>`. The method searches for a tuple or a set of"
+" tuples in the given space against a particular index and works similar to "
+":doc:`/reference/reference_lua/box_index/select`."
+msgstr ""
+
+msgid ""
+"This is an alternative to :ref:`space.update() "
+"<tntcxx_api_connection_update>`. The method updates a tuple in the given "
+"space but searches for the tuple against a particular index. The method "
+"works similar to :doc:`/reference/reference_lua/box_index/update`."
+msgstr ""
+
+msgid ""
+"The ``tuple`` parameter specifies an update operation, an identifier of the "
+"field to update, and a new field value. The set of available operations and "
+"the format of specifying an operation and a field identifier is the same as "
+"in Tarantool. Refer to the description of :doc:` "
+"</reference/reference_lua/box_index/update>` and example below for details."
+msgstr ""
+
+msgid ""
+"This is an alternative to :ref:`space.delete_() "
+"<tntcxx_api_connection_delete>`. The method deletes a tuple in the given "
+"space but searches for the tuple against a particular index. The method "
+"works similar to :doc:`/reference/reference_lua/box_index/delete`."
+msgstr ""

--- a/doc/locale/ru/LC_MESSAGES/doc/tntcxx_getting_started.po
+++ b/doc/locale/ru/LC_MESSAGES/doc/tntcxx_getting_started.po
@@ -1,0 +1,453 @@
+
+msgid "Connecting to Tarantool from C++"
+msgstr ""
+
+msgid ""
+"To simplify the start of your working with the Tarantool C++ connector, we "
+"will use the `example application "
+"<https://github.com/tarantool/tntcxx/blob/master/examples/Simple.cpp>`_ from"
+" the connector repository. We will go step by step through the application "
+"code and explain what each part does."
+msgstr ""
+
+msgid "The following main topics are discussed in this manual:"
+msgstr ""
+
+msgid "Pre-requisites"
+msgstr ""
+
+msgid ""
+"To go through this Getting Started exercise, you need the following pre-"
+"requisites to be done:"
+msgstr ""
+
+msgid ""
+":ref:`clone the connector source code and ensure having Tarantool and third-"
+"party software <gs_cxx_prereq_install>`"
+msgstr ""
+
+msgid ":ref:`start Tarantool and create a database <gs_cxx_prereq_tnt_run>`"
+msgstr ""
+
+msgid ":ref:`set up access rights <gs_cxx_prereq_access>`."
+msgstr ""
+
+msgid "Installation"
+msgstr ""
+
+msgid "The Tarantool C++ connector is currently supported for Linux only."
+msgstr ""
+
+msgid ""
+"The connector itself is a header-only library, so, it doesn't require "
+"installation and building as such. All you need is to clone the connector "
+"source code and :ref:`embed <gs_cxx_connect_embed>` it in your C++ project."
+msgstr ""
+
+msgid ""
+"Also, make sure you have other necessary software and Tarantool installed."
+msgstr ""
+
+msgid ""
+"Make sure you have the following third-party software. If you miss some of "
+"the items, install them:"
+msgstr ""
+
+msgid ""
+"`Git <https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>`_, a "
+"version control system"
+msgstr ""
+
+msgid ""
+"`unzip utility <https://linuxize.com/post/how-to-unzip-files-in-"
+"linux/#installing-unzip>`_"
+msgstr ""
+
+msgid ""
+"`gcc compiler <https://gcc.gnu.org/install/>`_ complied with the `C++17 "
+"standard <https://gcc.gnu.org/projects/cxx-status.html#cxx17>`_"
+msgstr ""
+
+msgid "`cmake and make tools <https://cmake.org/install/>`_."
+msgstr ""
+
+msgid "If you don't have Tarantool on your OS, install it in one of the ways:"
+msgstr ""
+
+msgid ""
+"from a package--refer to `OS-specific instructions "
+"<https://www.tarantool.io/en/download/>`_"
+msgstr ""
+
+msgid ""
+"from the `source <https://www.tarantool.io/en/download/os-"
+"installation/building-from-source/>`_."
+msgstr ""
+
+msgid "Clone the Tarantool C++ connector repository."
+msgstr ""
+
+msgid "Starting Tarantool and creating a database"
+msgstr ""
+
+msgid ""
+"Start Tarantool :ref:`locally <getting_started-using_package_manager>` or "
+":ref:`in Docker <getting_started-using_docker>` and create a space with the "
+"following schema and index:"
+msgstr ""
+
+msgid ""
+"Do not close the terminal window where Tarantool is running. You will need "
+"it later to connect to Tarantool from your C++ application."
+msgstr ""
+
+msgid "Setting up access rights"
+msgstr ""
+
+msgid ""
+"To be able to execute the necessary operations in Tarantool, you need to "
+"grant the ``guest`` user with the read-write rights. The simplest way is to "
+"grant the user with the :ref:`super role <authentication-roles>`:"
+msgstr ""
+
+msgid "Connecting to Tarantool"
+msgstr ""
+
+msgid ""
+"There are three main parts of the C++ connector: the IO-zero-copy buffer, "
+"the msgpack encoder/decoder, and the client that handles requests."
+msgstr ""
+
+msgid ""
+"To set up connection to a Tarantool instance from a C++ application, you "
+"need to do the following:"
+msgstr ""
+
+msgid ":ref:`embed the connector into the application <gs_cxx_connect_embed>`"
+msgstr ""
+
+msgid ""
+":ref:`instantiate a connector client and a connection object "
+"<gs_cxx_connect_instantiate>`"
+msgstr ""
+
+msgid ""
+":ref:`define connection parameters and invoke the method to connect "
+"<gs_cxx_connect_connecting>`"
+msgstr ""
+
+msgid ":ref:`define error handling behavior <gs_cxx_connect_error>`."
+msgstr ""
+
+msgid "Embedding connector"
+msgstr ""
+
+msgid ""
+"Embed the connector in your C++ application by including the main header:"
+msgstr ""
+
+msgid "Instantiating objects"
+msgstr ""
+
+msgid ""
+"First, we should create a connector client. It can handle many connections "
+"to Tarantool instances asynchronously. To instantiate a client, you should "
+"specify the buffer and the network provider implementations as template "
+"parameters. The connector's main class has the following signature:"
+msgstr ""
+
+msgid ""
+"The buffer is parametrized by allocator. It means that users can choose "
+"which allocator will be used to provide memory for the buffer's blocks. Data"
+" is organized into a linked list of blocks of fixed size that is specified "
+"as the template parameter of the buffer."
+msgstr ""
+
+msgid ""
+"You can either implement your own buffer or network provider or use the "
+"default ones as we do in our example. So, the default connector "
+"instantiation looks as follows:"
+msgstr ""
+
+msgid ""
+"To use the ``BUFFER`` class, the buffer header should also be included:"
+msgstr ""
+
+msgid ""
+"A client itself is not enough to work with Tarantool instances--we also need"
+" to create connection objects. A connection also takes the buffer and the "
+"network provider as template parameters. Note that they must be the same as "
+"ones of the client:"
+msgstr ""
+
+msgid "Connecting"
+msgstr ""
+
+msgid ""
+"Our :ref:`Tarantool instance <gs_cxx_prereq_tnt_run>` is listening to the "
+"``3301`` port on ``localhost``. Let's define the corresponding variables as "
+"well as the ``WAIT_TIMEOUT`` variable for connection timeout."
+msgstr ""
+
+msgid ""
+"To connect to the Tarantool instance, we should invoke the "
+"``Connector::connect()`` method of the client object and pass three "
+"arguments: connection instance, address, and port."
+msgstr ""
+
+msgid "Error handling"
+msgstr ""
+
+msgid ""
+"Implementation of the connector is exception free, so we rely on the return "
+"codes: in case of fail, the ``connect()`` method returns ``rc < 0``. To get "
+"the error message corresponding to the last error occured during "
+"communication with the instance, we can invoke the "
+"``Connection::getError()`` method."
+msgstr ""
+
+msgid ""
+"To reset connection after errors, that is, to clean up the error message and"
+" connection status, the ``Connection::reset()`` method is used."
+msgstr ""
+
+msgid "Working with requests"
+msgstr ""
+
+msgid "In this section, we will show how to:"
+msgstr ""
+
+msgid ":ref:`prepare different types of requests <gs_cxx_requests_prepare>`"
+msgstr ""
+
+msgid ":ref:`send the requests <gs_cxx_requests_send>`"
+msgstr ""
+
+msgid ":ref:`receive and handle responses <gs_cxx_requests_response>`."
+msgstr ""
+
+msgid ""
+"We will also go through the :ref:`case of having several connections "
+"<gs_cxx_requests_several>` and executing a number of requests from different"
+" connections simultaneously."
+msgstr ""
+
+msgid ""
+"In our example C++ application, we execute the following types of requests:"
+msgstr ""
+
+msgid "``ping``"
+msgstr ""
+
+msgid "``replace``"
+msgstr ""
+
+msgid "``select``."
+msgstr ""
+
+msgid ""
+"Examples on other request types, namely, ``insert``, ``delete``, ``upsert``,"
+" and ``update``, will be added to this manual later."
+msgstr ""
+
+msgid ""
+"Each request method returns a request ID that is a sort of `future "
+"<https://en.wikipedia.org/wiki/Futures_and_promises>`_. This ID can be used "
+"to get the response message when it is ready. Requests are queued in the "
+"output buffer of connection until the ``Connector::wait()`` method is "
+"called."
+msgstr ""
+
+msgid "Preparing requests"
+msgstr ""
+
+msgid ""
+"At this step, requests are encoded in the `MessagePack "
+"<https://msgpack.org/>`_ format and saved in the output connection buffer. "
+"They are ready to be sent but the network communication itself will be done "
+"later."
+msgstr ""
+
+msgid ""
+"Let's remind that for the requests manipulating with data we are dealing "
+"with the Tarantool space ``t`` :ref:`created earlier "
+"<gs_cxx_prereq_tnt_run>`, and the space has the following format:"
+msgstr ""
+
+msgid "**ping**"
+msgstr ""
+
+msgid "**replace**"
+msgstr ""
+
+msgid "Equals to Lua request ``<space_name>:replace(pk_value, \"111\", 1)``."
+msgstr ""
+
+msgid "**select**"
+msgstr ""
+
+msgid ""
+"Equals to Lua request ``<space_name>.index[0]:select({pk_value}, {limit = "
+"1})``."
+msgstr ""
+
+msgid "Sending requests"
+msgstr ""
+
+msgid ""
+"To send requests to the server side, invoke the ``client.wait()`` method."
+msgstr ""
+
+msgid ""
+"The ``wait()`` method takes the connection to poll, the request ID, and, "
+"optionally, the timeout as parameters. Once a response for the specified "
+"request is ready, ``wait()`` terminates. It also provides a negative return "
+"code in case of system related fails, for example, a broken or timeouted "
+"connection. If ``wait()`` returns ``0``, then a response has been received "
+"and expected to be parsed."
+msgstr ""
+
+msgid ""
+"Now let's send our requests to the Tarantool instance. The "
+"``futureIsReady()`` function checks availability of a future and returns "
+"``true`` or ``false``."
+msgstr ""
+
+msgid "Receiving responses"
+msgstr ""
+
+msgid ""
+"To get the response when it is ready, use the ``Connection::getResponse()`` "
+"method. It takes the request ID and returns an optional object containing "
+"the response. If the response is not ready yet, the method returns "
+"``std::nullopt``. Note that on each future, ``getResponse()`` can be called "
+"only once: it erases the request ID from the internal map once it is "
+"returned to a user."
+msgstr ""
+
+msgid ""
+"A response consists of a header and a body (``response.header`` and "
+"``response.body``). Depending on success of the request execution on the "
+"server side, body may contain either runtime error(s) accessible by "
+"``response.body.error_stack`` or data (tuples)--``response.body.data``. In "
+"turn, data is a vector of tuples. However, tuples are not decoded and come "
+"in the form of pointers to the start and the end of msgpacks. See the "
+":ref:`\"Decoding and reading the data\" <gs_cxx_reader>` section to "
+"understand how to decode tuples."
+msgstr ""
+
+msgid ""
+"There are two options for single connection it regards to receiving "
+"responses: we can either wait for one specific future or for all of them at "
+"once. We'll try both options in our example. For the ``ping`` request, let's"
+" use the first option."
+msgstr ""
+
+msgid ""
+"For the ``replace`` and ``select`` requests, let's examine the option of "
+"waiting for both futures at once."
+msgstr ""
+
+msgid "Several connections at once"
+msgstr ""
+
+msgid ""
+"Now, let's have a look at the case when we establish two connections to "
+"Tarantool instance simultaneously."
+msgstr ""
+
+msgid "Closing connections"
+msgstr ""
+
+msgid "Finally, a user is responsible for closing connections."
+msgstr ""
+
+msgid "Building and launching C++ application"
+msgstr ""
+
+msgid ""
+"Now, we are going to build our example C++ application, launch it to connect"
+" to the Tarantool instance and execute all the requests defined."
+msgstr ""
+
+msgid ""
+"Make sure you are in the root directory of the cloned C++ connector "
+"repository. To build the example application:"
+msgstr ""
+
+msgid ""
+"Make sure the :ref:`Tarantool session <gs_cxx_prereq_tnt_run>` you started "
+"earlier is running. Launch the application:"
+msgstr ""
+
+msgid ""
+"As you can see from the execution log, all the connections to Tarantool "
+"defined in our application have been established and all the requests have "
+"been executed successfully."
+msgstr ""
+
+msgid "Decoding and reading the data"
+msgstr ""
+
+msgid ""
+"Responses from a Tarantool instance contain raw data, that is, the data "
+"encoded into the `MessagePack <https://msgpack.org/>`_ tuples. To decode "
+"client's data, the user has to write their own decoders (readers) based on "
+"the database schema and include them in one's application:"
+msgstr ""
+
+msgid ""
+"To show the logic of decoding a response, we will use `the reader from our "
+"example "
+"<https://github.com/tarantool/tntcxx/blob/master/examples/Reader.hpp>`_."
+msgstr ""
+
+msgid ""
+"First, the structure corresponding our :ref:`example space format "
+"<gs_cxx_prereq_tnt_run>` is defined:"
+msgstr ""
+
+msgid "Base reader prototype"
+msgstr ""
+
+msgid "Prototype of the base reader is given in ``src/mpp/Dec.hpp``:"
+msgstr ""
+
+msgid ""
+"Every new reader should inherit from it or directly from the "
+"``DefaultErrorHandler``."
+msgstr ""
+
+msgid "Parsing values"
+msgstr ""
+
+msgid ""
+"To parse a particular value, we should define the ``Value()`` method. First "
+"two arguments of the method are common and unused as a rule, but the third "
+"one defines the parsed value. In case of `POD (Plain Old Data) "
+"<https://en.wikipedia.org/wiki/Passive_data_structure>`_ structures, it's "
+"enough to provide a byte-to-byte copy. Since there are fields of three "
+"different types in our schema, let's define the corresponding ``Value()`` "
+"functions:"
+msgstr ""
+
+msgid "Parsing array"
+msgstr ""
+
+msgid ""
+"It's also important to understand that a tuple itself is wrapped in an "
+"array, so, in fact, we should parse the array first. Let's define another "
+"reader for that purpose."
+msgstr ""
+
+msgid "Setting reader"
+msgstr ""
+
+msgid ""
+"The ``SetReader()`` method sets the reader that is invoked while each of the"
+" array's entries is parsed. To make two readers defined above work, we "
+"should create a decoder, set its iterator to the position of the encoded "
+"tuple, and invoke the ``Read()`` method (the code block below is from the "
+"`example application "
+"<https://github.com/tarantool/tntcxx/blob/master/examples/Simple.cpp>`_)."
+msgstr ""

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,3 @@
+Sphinx==4.0.2
+sphinx-intl==2.0.1
+polib==1.1.1


### PR DESCRIPTION
Documentation sources are .rst files where a tech writer or a developer writes documentation. As soon as we have two languages supported on our website we need to maintain translated 100% of the documentation. For translation, we use Crowdin - saas solution for translating any texts.  
While a new PR with changes in .rst is opened, the translations for these changes are preparing by translators in Crowdin.  
When the translations are ready we can run __Pull translations__ job to download and commit translations into the PR branch.  
This diagram shows how the process works:
![crowdin-time-diagram](https://user-images.githubusercontent.com/23726173/124887107-8c53ca00-dfdd-11eb-9552-5154e469fa33.png)

- add cleanup.py for re-arranging .po files and initial re-arranged .po files
- push-translation.yml push translation sources to Crowdin on pull request when .rst is changed, create a deployment with a link to Crowdin translations
- pull-translation.yml for getting translations from Crowdin on demand when translation is ready and auto-commit them into the same PR branch
- upload-translations.yml for upload translations to the master Crowdin branch from the git master branch
- destroy deployment with a link to Crowdin translations when the translations (in PR) are merged
- conf.py for sphinx
- add requirements.txt with packages for doc build
- modify .gitignore for doc builds

Closes #14