### PR TITLE
Providing SQL statements

### DIFF
--- a/src/Client/Connection.hpp
+++ b/src/Client/Connection.hpp
@@ -158,6 +158,25 @@ public:
 	template <class T>
 	rid_t call(const std::string &func, const T &args);
 	rid_t ping();
+	
+	/**
+	 * Execute the SQL statement contained in the 'statement' parameter.
+	 * @param statement statement, which should conform to the rules for SQL grammar
+	 * @param parameters tuple for placeholders in the statement
+	 * @retval request id
+	 */
+	 
+	template <class T>
+	rid_t execute(const std::string& statement, const T& parameters);
+
+	/**
+	 * Execute the SQL statement contained in the 'statement' parameter.
+	 * @param stmt_id the statement id obtained with prepare()
+	 * @param parameters tuple for placeholders in the statement
+	 * @retval request id
+	 */
+	template <class T>
+	rid_t execute(unsigned int stmt_id, const T& parameters);
 
 	void setError(const std::string &msg, int errno_ = 0);
 	ConnectionError& getError();
@@ -581,6 +600,25 @@ decodeGreeting(Connection<BUFFER, NetProvider> &conn)
 }
 
 ////////////////////////////BOX-like interface functions////////////////////////
+template<class BUFFER, class NetProvider>
+template <class T>
+rid_t
+Connection<BUFFER, NetProvider>::execute(const std::string& statement, const T& parameters)
+{
+    impl->enc.encodeExecute(statement, parameters);
+    impl->connector.readyToSend(*this);
+    return RequestEncoder<BUFFER>::getSync();
+}
+
+template<class BUFFER, class NetProvider>
+template <class T>
+rid_t
+Connection<BUFFER, NetProvider>::execute(unsigned int stmt_id, const T& parameters)
+{
+    impl->enc.encodeExecute(stmt_id, parameters);
+    impl->connector.readyToSend(*this);
+    return RequestEncoder<BUFFER>::getSync();
+}
 
 template<class BUFFER, class NetProvider>
 template <class T>

--- a/src/Client/Connection.hpp
+++ b/src/Client/Connection.hpp
@@ -178,6 +178,14 @@ public:
 	template <class T>
 	rid_t execute(unsigned int stmt_id, const T& parameters);
 
+    /**
+    * Prepare the SQL statement contained in the 'statement' parameter.
+    * The syntax and requirements for Connection::prepare() are the same as for Connection::execute().
+    * @param statement statement, which should conform to the rules for SQL grammar
+    * @retval request id
+    */
+    rid_t prepare(const std::string& statement);
+
 	void setError(const std::string &msg, int errno_ = 0);
 	ConnectionError& getError();
 	void reset();
@@ -616,6 +624,15 @@ rid_t
 Connection<BUFFER, NetProvider>::execute(unsigned int stmt_id, const T& parameters)
 {
     impl->enc.encodeExecute(stmt_id, parameters);
+    impl->connector.readyToSend(*this);
+    return RequestEncoder<BUFFER>::getSync();
+}
+
+template<class BUFFER, class NetProvider>
+rid_t
+Connection<BUFFER, NetProvider>::prepare(const std::string& statement)
+{
+    impl->enc.encodePrepare(statement);
     impl->connector.readyToSend(*this);
     return RequestEncoder<BUFFER>::getSync();
 }

--- a/src/Client/IprotoConstants.hpp
+++ b/src/Client/IprotoConstants.hpp
@@ -102,6 +102,13 @@ namespace Iproto {
 		FIELD_SPAN = 5,
 	};
 
+	enum ColumnMap {
+		FIELD_NAME_MAX = 256,
+		FIELD_TYPE_NAME_MAX = 32,
+		COLLATION_MAX = 32,
+		SPAN_MAX = 256
+	};
+
 	enum Type {
 		OK = 0,
 		SELECT = 1,
@@ -133,6 +140,12 @@ namespace Iproto {
 		VY_RUN_ROW_INDEX = 102,
 		CHUNK = 128,
 		TYPE_ERROR = 1 << 15
+	};
+
+	/** Keys of IPROTO_SQL_INFO map. */
+	enum SqlInfoKey {
+		SQL_INFO_ROW_COUNT = 0x00,
+		SQL_INFO_AUTOINCREMENT_IDS = 0x01
 	};
 
 	enum ErrorStack {

--- a/src/Client/RequestEncoder.hpp
+++ b/src/Client/RequestEncoder.hpp
@@ -86,6 +86,7 @@ public:
 	size_t encodeExecute(const std::string& statement, const T& parameters);
 	template <class T>
 	size_t encodeExecute(unsigned int stmt_id, const T& parameters);
+	size_t encodePrepare(const std::string& statement);
 	template <class T>
 	size_t encodeCall(const std::string &func, const T &args);
 
@@ -271,6 +272,21 @@ RequestEncoder<BUFFER>::encodeExecute(unsigned int stmt_id, const T& parameters)
 		MPP_AS_CONST(Iproto::STMT_ID), stmt_id,
 		MPP_AS_CONST(Iproto::SQL_BIND), parameters,
 		MPP_AS_CONST(Iproto::OPTIONS), std::make_tuple())));
+	uint32_t request_size = (m_Buf.end() - request_start) - PREHEADER_SIZE;
+	m_Buf.set(request_start + 1, __builtin_bswap32(request_size));
+	return request_size + PREHEADER_SIZE;
+}
+
+template<class BUFFER>
+size_t
+RequestEncoder<BUFFER>::encodePrepare(const std::string& statement)
+{
+	iterator_t<BUFFER> request_start = m_Buf.end();
+	m_Buf.addBack('\xce');
+	m_Buf.addBack(uint32_t{0});
+	encodeHeader(Iproto::PREPARE);
+	m_Enc.add(mpp::as_map(std::forward_as_tuple(
+		MPP_AS_CONST(Iproto::SQL_TEXT), statement)));
 	uint32_t request_size = (m_Buf.end() - request_start) - PREHEADER_SIZE;
 	m_Buf.set(request_start + 1, __builtin_bswap32(request_size));
 	return request_size + PREHEADER_SIZE;

--- a/src/Client/ResponseReader.hpp
+++ b/src/Client/ResponseReader.hpp
@@ -79,16 +79,16 @@ struct SqlInfo
 
 struct ColumnMap
 {
-	char field_name[Iproto::FIELD_NAME_MAX];
-	size_t field_name_len;
-	char field_type[Iproto::FIELD_TYPE_NAME_MAX];
-	size_t field_type_len;
-	char collation[Iproto::COLLATION_MAX];
-	size_t collation_len;
-	bool is_nullable;
-	bool is_autoincrement;
-	char span[Iproto::SPAN_MAX];
-	size_t span_len;
+	char field_name[Iproto::FIELD_NAME_MAX] = {};
+	size_t field_name_len = 0;
+	char field_type[Iproto::FIELD_TYPE_NAME_MAX] = {};
+	size_t field_type_len = 0;
+	char collation[Iproto::COLLATION_MAX] = {};
+	size_t collation_len  = 0;
+	bool is_nullable      = 0;
+	bool is_autoincrement = 0;
+	char span[Iproto::SPAN_MAX] = {};
+	size_t span_len = 0;
 };
 
 struct Metadata
@@ -402,29 +402,35 @@ struct ColumnMapKeyReader : mpp::SimpleReaderBase<BUFFER, mpp::MP_UINT> {
 		using CollationReader_t = mpp::SimpleStrReader<BUFFER, sizeof(ColumnMap{}.collation)>;
 		using SpanReader_t = mpp::SimpleStrReader<BUFFER, sizeof(ColumnMap{}.span)>;
 		using Bool_t = mpp::SimpleReader<BUFFER, mpp::MP_BOOL, bool>;
-		//TODO: handle "access denied" and custom errors
+		LOG_DEBUG("Column map switch.....................");
 		switch (key) {
 			case Iproto::FIELD_NAME: {
+				LOG_DEBUG("field name.....................");
 				dec.SetReader(true, FieldNameReader_t{column_map.field_name, column_map.field_name_len});
 				break;
 			}
 			case Iproto::FIELD_TYPE: {
+				LOG_DEBUG("Field type.....................");
 				dec.SetReader(true, FieldTypeReader_t{column_map.field_type, column_map.field_type_len});
 				break;
 			}
 			case Iproto::FIELD_COLL: {
+				LOG_DEBUG("Collation.....................");
 				dec.SetReader(true, CollationReader_t{column_map.collation, column_map.collation_len});
 				break;
 			}
 			case Iproto::FIELD_IS_NULLABLE: {
+				LOG_DEBUG("is nullable.....................");
 				dec.SetReader(true, Bool_t{column_map.is_nullable});
 				break;
 			}
 			case Iproto::FIELD_IS_AUTOINCREMENT: {
+				LOG_DEBUG("auto increment.....................");
 				dec.SetReader(true, Bool_t{column_map.is_autoincrement});
 				break;
 			}
 			case Iproto::FIELD_SPAN: {
+				LOG_DEBUG("span.....................");
 				dec.SetReader(true, SpanReader_t{column_map.span, column_map.span_len});
 				break;
 			}
@@ -447,6 +453,7 @@ struct MetadataArrayValueReader : mpp::SimpleReaderBase<BUFFER, mpp::MP_MAP> {
 		metadata.column_maps.push_back(ColumnMap());
 		metadata.dimension += 1;
 		dec.SetReader(false, ColumnMapKeyReader<BUFFER>{dec, metadata.column_maps.back()});
+		LOG_DEBUG("MetadataArrayValueReader..........");
 
 	}
 	mpp::Dec<BUFFER>& dec;
@@ -461,6 +468,7 @@ struct MetadataArrayReader : mpp::SimpleReaderBase<BUFFER, mpp::MP_ARR> {
 	void Value(const iterator_t<BUFFER>&, mpp::compact::Type, mpp::ArrValue)
 	{
 		dec.SetReader(false, MetadataArrayValueReader<BUFFER>{dec, metadata});
+		LOG_DEBUG("MetadataArrayReader..........");
 	}
 	mpp::Dec<BUFFER>& dec;
 	Metadata& metadata;

--- a/test/cfg.lua
+++ b/test/cfg.lua
@@ -1,6 +1,9 @@
 box.cfg{listen = 3301, net_msg_max=10000, readahead=163200, log='tarantool.txt'}
 box.schema.user.grant('guest', 'super', nil, nil, {if_not_exists=true})
 
+sset = box.space._session_settings
+sset:update('sql_full_metadata', {{'=', 'value', true}})
+
 if box.space.t then box.space.t:drop() end
 s = box.schema.space.create('T')
 s:format{{name='id',type='integer'},{name='a',type='string'},{name='b',type='number'}}


### PR DESCRIPTION
Added support for sql queries. Implemented methods:
* ```Connection::execute()``` - equivalent of  [box.execute()](https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_sql/execute/)
* ```Connection::prepare()``` - equivalent of [box.prepare()](https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_sql/prepare/)

Added new structures ```ColumnMap```, ```SqlInfo```, ```Metadata``` and readers for them.
Added tests for the methods above.