### PR TITLE
ci: build and test tntcxx on macos 11 and 12

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,8 +20,12 @@ jobs:
         mode:
           - Debug
           - Release
+        test-ssl:
+          - Disabled
 
     runs-on: ${{ matrix.runs-on }}
+
+    name: ${{ matrix.runs-on }} (${{ matrix.mode }}, ${{ matrix.test-ssl }} ssl test)
 
     steps:
       - name: Clone the connector
@@ -41,8 +45,13 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DCMAKE_BUILD_TYPE=${{ matrix.mode }} -DTNTCXX_BUILD_TESTING=ON -DTNTCXX_ENABLE_SSL=OFF .. 
+          cmake -DCMAKE_BUILD_TYPE=${{ matrix.mode }} -DTNTCXX_BUILD_TESTING=ON -DTNTCXX_ENABLE_SSL=ON ..
           make -j
 
+      - name: test without SSL
+        if: matrix.test-ssl == 'Disabled'
+        run: cd build && ctest --output-on-failure -E ClientSSL.test
+
       - name: test
+        if: matrix.test-ssl == 'Enabled'
         run: cd build && ctest --output-on-failure

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,4 +1,4 @@
-name: ubuntu
+name: testing
 
 on:
   workflow_dispatch:
@@ -15,8 +15,8 @@ jobs:
         runs-on:
           - ubuntu-20.04
           - ubuntu-22.04
-        tarantool:
-          - '2.11'
+          - macos-11
+          - macos-12
         mode:
           - Debug
           - Release
@@ -27,10 +27,15 @@ jobs:
       - name: Clone the connector
         uses: actions/checkout@v3
 
-      - name: Setup tarantool ${{ matrix.tarantool }}
+      - name: Setup tarantool 2.11
+        if: startsWith(matrix.runs-on, 'ubuntu')
         uses: tarantool/setup-tarantool@v1
         with:
-          tarantool-version: ${{ matrix.tarantool }}
+          tarantool-version: '2.11'
+
+      - name: Setup stable tarantool from brew
+        if: startsWith(matrix.runs-on, 'macos')
+        run: brew install tarantool
 
       - name: build
         run: |
@@ -38,5 +43,6 @@ jobs:
           cd build
           cmake -DCMAKE_BUILD_TYPE=${{ matrix.mode }} -DTNTCXX_BUILD_TESTING=ON -DTNTCXX_ENABLE_SSL=OFF .. 
           make -j
+
       - name: test
         run: cd build && ctest --output-on-failure

--- a/src/Utils/Traits.hpp
+++ b/src/Utils/Traits.hpp
@@ -81,6 +81,7 @@
  */
 
 #include <cstddef>
+#include <iterator>
 #include <tuple>
 #include <type_traits>
 #include <variant>

--- a/test/EncDecTest.cpp
+++ b/test/EncDecTest.cpp
@@ -33,6 +33,7 @@
 
 #include <set>
 #include <map>
+#include <vector>
 
 #include "Utils/Helpers.hpp"
 #include "Utils/RefVector.hpp"


### PR DESCRIPTION
The project is tested in both Release and Debug modes on each version of
macos. Tarantool is installed from brew, the last stable version is used.