### PR TITLE
ci: build and test tntcxx on ubuntu 22.04

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,4 +1,4 @@
-name: debug
+name: ubuntu
 
 on:
   workflow_dispatch:
@@ -8,17 +8,20 @@ on:
     tags: [ "*" ]
 
 jobs:
-  ubuntu_20_04:
-    runs-on: ubuntu-20.04
-
+  ubuntu:
     strategy:
       fail-fast: false
       matrix:
+        runs-on:
+          - ubuntu-20.04
+          - ubuntu-22.04
         tarantool:
           - '2.11'
         mode:
           - Debug
           - Release
+
+    runs-on: ${{ matrix.runs-on }}
 
     steps:
       - name: Clone the connector

--- a/src/Utils/Common.hpp
+++ b/src/Utils/Common.hpp
@@ -44,6 +44,8 @@
  */
 
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
 #include <tuple>
 
 namespace tnt {

--- a/test/BufferPerfTest.cpp
+++ b/test/BufferPerfTest.cpp
@@ -280,7 +280,7 @@ bench(T (&in)[N], T (&out)[N])
 	std::cout << "---------------------------------------" << std::endl;
 	std::cout << "Bench of " << contName(cont) << (LIGHT ? " (light)" : "")
 		  << " with " << dataName(in[0]) << std::endl;
-	memset(out, 0, sizeof(out));
+	std::fill(std::begin(out), std::end(out), T());
 	PerfTimer timer;
 
 	// Write

--- a/test/Utils/TupleReader.hpp
+++ b/test/Utils/TupleReader.hpp
@@ -36,9 +36,9 @@
 
 /** Corresponds to data stored in _space[512]. */
 struct UserTuple {
-	uint64_t field1;
+	uint64_t field1 = 0;
 	std::string field2;
-	double field3;
+	double field3 = 0.0;
 	void *field4 = reinterpret_cast<void *>(0xDEADBEEF);
 	std::pair<std::string, uint64_t> field5;
 };


### PR DESCRIPTION
The patch provides CI with ubuntu 22.04 runner and fixes all build issues related to both ubuntu 22.04 and 20.04.