### PR TITLE
[DO NOT MERGE] ci: check which tests are actually run

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: test without SSL
         if: matrix.test-ssl == 'Disabled'
-        run: cd build && ctest --output-on-failure -E ClientSSL.test
+        run: cd build && ctest --verbose --output-on-failure -E ClientSSL.test
 
       - name: test
         if: matrix.test-ssl == 'Enabled'


### PR DESCRIPTION
Check which tests are actually run by enabling verbose ctest output.