### PR TITLE
 mpp: introduce object encoding/decoding

### DIFF
--- a/src/Utils/Common.hpp
+++ b/src/Utils/Common.hpp
@@ -52,7 +52,7 @@ namespace tnt {
 /**
  * Delayer of static_assert evaluation.
  */
-template <class>
+template <class...>
 constexpr bool always_false_v = false;
 
 /**

--- a/src/Utils/Traits.hpp
+++ b/src/Utils/Traits.hpp
@@ -300,25 +300,17 @@ constexpr bool has_get_by_size_v = details::has_get_by_size_h<I, U>::value;
  * 2. Call std::get otherwise.
  */
 template <class T, class U>
-constexpr std::enable_if_t<has_get_by_type_v<T, U>, T&> get(U& u)
+constexpr std::enable_if_t<has_get_by_type_v<T, U>,
+	decltype(std::declval<U>().template get<T>())> get(U&& u)
 {
-	return u.template get<T>();
-}
-template <class T, class U>
-constexpr std::enable_if_t<has_get_by_type_v<T, U>, const T&> get(const U& u)
-{
-	return u.template get<T>();
+	return std::forward<U>(u).template get<T>();
 }
 
 template <class T, class U>
-constexpr std::enable_if_t<!has_get_by_type_v<T, U>, T&> get(U& u)
+constexpr std::enable_if_t<!has_get_by_type_v<T, U>,
+	decltype(std::get<T>(std::declval<U>()))> get(U&& u)
 {
-	return std::get<T>(u);
-}
-template <class T, class U>
-constexpr std::enable_if_t<!has_get_by_type_v<T, U>, const T&> get(const U& u)
-{
-	return std::get<T>(u);
+	return std::get<T>(std::forward<U>(u));
 }
 
 /**
@@ -336,30 +328,16 @@ constexpr std::enable_if_t<is_bounded_array_v<U>,
 
 template <size_t I, class U>
 constexpr std::enable_if_t<has_get_by_size_v<I, U>,
-	decltype(std::declval<U&>().template get<I>())> get(U& u)
+	decltype(std::declval<U>().template get<I>())> get(U&& u)
 {
-	return u.template get<I>();
-}
-
-template <size_t I, class U>
-constexpr std::enable_if_t<has_get_by_size_v<I, U>,
-	decltype(std::declval<const U&>().template get<I>())> get(const U& u)
-{
-	return u.template get<I>();
+	return std::forward<U>(u).template get<I>();
 }
 
 template <size_t I, class U>
 constexpr std::enable_if_t<!is_bounded_array_v<U> && !has_get_by_size_v<I, U>,
-	decltype(std::get<I>(std::declval<U&>()))> get(U& u)
+	decltype(std::get<I>(std::declval<U>()))> get(U&& u)
 {
-	return std::get<I>(u);
-}
-
-template <size_t I, class U>
-constexpr std::enable_if_t<!is_bounded_array_v<U> && !has_get_by_size_v<I, U>,
-	decltype(std::get<I>(std::declval<const U&>()))> get(const U& u)
-{
-	return std::get<I>(u);
+	return std::get<I>(std::forward<U>(u));
 }
 
 /**

--- a/src/mpp/ClassRule.hpp
+++ b/src/mpp/ClassRule.hpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2010-2023 Tarantool AUTHORS: please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY AUTHORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * AUTHORS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "../Utils/Common.hpp"
+
+template <class T> struct mpp_rule;
+template <class T> struct mpp_enc_rule;
+template <class T> struct mpp_dec_rule;
+
+namespace mpp {
+
+namespace details {
+template <class T>
+struct has_member_base {
+	static constexpr bool value = !std::is_member_pointer_v<T>;
+};
+
+template <class T, typename = void>
+struct has_member_rule_h : std::false_type {};
+template <class T>
+struct has_member_rule_h<T, std::void_t<decltype(T::mpp)>>
+	: has_member_base<decltype(&T::mpp)> {};
+
+template <class T, typename = void>
+struct has_member_enc_rule_h : std::false_type {};
+template <class T>
+struct has_member_enc_rule_h<T, std::void_t<decltype(T::mpp_enc)>>
+	: has_member_base<decltype(&T::mpp_enc)> {};
+
+template <class T, typename = void>
+struct has_member_dec_rule_h : std::false_type {};
+template <class T>
+struct has_member_dec_rule_h<T, std::void_t<decltype(T::mpp_dec)>>
+	: has_member_base<decltype(&T::mpp_dec)> {};
+
+template <class T, typename = void>
+struct has_spec_rule_h : std::false_type {};
+template <class T>
+struct has_spec_rule_h<T, std::void_t<decltype(mpp_rule<T>::value)>>
+	: has_member_base<decltype(&mpp_rule<T>::value)> {};
+
+template <class T, typename = void>
+struct has_spec_enc_rule_h : std::false_type {};
+template <class T>
+struct has_spec_enc_rule_h<T, std::void_t<decltype(mpp_enc_rule<T>::value)>>
+	: has_member_base<decltype(&mpp_enc_rule<T>::value)> {};
+
+template <class T, typename = void>
+struct has_spec_dec_rule_h : std::false_type {};
+template <class T>
+struct has_spec_dec_rule_h<T, std::void_t<decltype(mpp_dec_rule<T>::value)>>
+	: has_member_base<decltype(&mpp_dec_rule<T>::value)> {};
+} // namespace details
+
+template <class T>
+constexpr bool has_enc_rule_v =
+	details::has_member_rule_h<T>::value ||
+	details::has_member_enc_rule_h<T>::value ||
+	details::has_spec_rule_h<T>::value ||
+	details::has_spec_enc_rule_h<T>::value;
+
+template <class T>
+constexpr bool has_dec_rule_v =
+	details::has_member_rule_h<T>::value ||
+	details::has_member_dec_rule_h<T>::value ||
+	details::has_spec_rule_h<T>::value ||
+	details::has_spec_dec_rule_h<T>::value;
+
+template <class T>
+constexpr auto& get_enc_rule()
+{
+	if constexpr (details::has_member_enc_rule_h<T>::value)
+		return T::mpp_enc;
+	else if constexpr (details::has_member_rule_h<T>::value)
+		return T::mpp;
+	else if constexpr (details::has_spec_enc_rule_h<T>::value)
+		return mpp_enc_rule<T>::value;
+	else if constexpr (details::has_spec_rule_h<T>::value)
+		return mpp_rule<T>::value;
+	else
+		static_assert(tnt::always_false_v<T>,
+			      "Failed to find a rule for given type");
+}
+
+template <class T>
+constexpr auto& get_dec_rule()
+{
+	if constexpr (details::has_member_dec_rule_h<T>::value)
+		return T::mpp_dec;
+	else if constexpr (details::has_member_rule_h<T>::value)
+		return T::mpp;
+	else if constexpr (details::has_spec_dec_rule_h<T>::value)
+		return mpp_dec_rule<T>::value;
+	else if constexpr (details::has_spec_rule_h<T>::value)
+		return mpp_rule<T>::value;
+	else
+		static_assert(tnt::always_false_v<T>,
+			      "Failed to find a rule for given type");
+}
+
+} // namespace mpp

--- a/src/mpp/Dec.hpp
+++ b/src/mpp/Dec.hpp
@@ -35,6 +35,7 @@
 #include <cstdint>
 #include <utility>
 
+#include "ClassRule.hpp"
 #include "Constants.hpp"
 #include "Rules.hpp"
 #include "Spec.hpp"

--- a/src/mpp/Enc.hpp
+++ b/src/mpp/Enc.hpp
@@ -37,6 +37,7 @@
 #include <variant>
 
 #include "BSwap.hpp"
+#include "ClassRule.hpp"
 #include "Constants.hpp"
 #include "Rules.hpp"
 #include "Spec.hpp"

--- a/src/mpp/Enc.hpp
+++ b/src/mpp/Enc.hpp
@@ -557,10 +557,18 @@ encode(CONT &cont, tnt::CStr<C...> prefix,
 			const V& v = u.v;
 			if constexpr(tnt::is_tuplish_v<V>) {
 				tnt::iseq<> is;
+				constexpr size_t N = sizeof...(I);
+				[[maybe_unused]] auto reorder =
+					std::tie(tnt::get<I>(v).first...,
+						 tnt::get<I>(v).second...);
+				[[maybe_unused]] auto reindex =
+					[](size_t i, size_t n) {
+						return i / 2 + n * (i % 2);
+					};
 				return encode(cont, prefix, is,
-					      tnt::get<I>(v).first...,
-					      tnt::get<I>(v).second...,
-					      more...);
+					tnt::get<reindex(I, N)>(reorder)...,
+					tnt::get<reindex(I + N, N)>(reorder)...,
+					more...);
 			} else if constexpr(tnt::is_const_iterable_v<V>) {
 				auto itr = std::begin(v);
 				auto e = std::end(v);

--- a/test/CommonUnitTest.cpp
+++ b/test/CommonUnitTest.cpp
@@ -94,5 +94,7 @@ test_tuple_utils()
 int main()
 {
 	static_assert(tnt::always_false_v<double> == false);
+	static_assert(tnt::always_false_v<int, double> == false);
+	static_assert(tnt::always_false_v<> == false);
 	test_tuple_utils();
 }

--- a/test/EncDecTest.cpp
+++ b/test/EncDecTest.cpp
@@ -1011,10 +1011,97 @@ test_basic()
 	}
 }
 
+struct JustClass {
+	int mpp;
+	using mpp_dec = int;
+};
+
+struct WithMppMemberRule {
+	int i;
+	static constexpr auto mpp = &WithMppMemberRule::i;
+};
+
+struct WithEncMemberRule {
+	int j;
+	static constexpr auto mpp_enc = std::make_tuple(&WithEncMemberRule::j);
+};
+
+struct WithDecMemberRule {
+	int k;
+	static constexpr auto mpp_dec = std::make_tuple(&WithDecMemberRule::k);
+};
+
+struct WithMppSpecRule {
+	int a;
+};
+
+struct WithEncSpecRule {
+	int b;
+};
+
+struct WithDecSpecRule {
+	int c;
+};
+
+template <>
+struct mpp_rule<WithMppSpecRule> {
+	static constexpr auto value = &WithMppSpecRule::a;
+};
+
+template <>
+struct mpp_enc_rule<WithEncSpecRule> {
+	static constexpr auto value = std::make_tuple(&WithEncSpecRule::b);
+};
+
+template <>
+struct mpp_dec_rule<WithDecSpecRule> {
+	static constexpr auto value = std::make_tuple(&WithDecSpecRule::c);
+};
+
+void test_class_rules()
+{
+	TEST_INIT(0);
+	static_assert(!mpp::has_enc_rule_v<JustClass>);
+	static_assert(!mpp::has_dec_rule_v<JustClass>);
+
+	static_assert(mpp::has_enc_rule_v<WithMppMemberRule>);
+	static_assert(mpp::has_dec_rule_v<WithMppMemberRule>);
+	static_assert(mpp::has_enc_rule_v<WithEncMemberRule>);
+	static_assert(!mpp::has_dec_rule_v<WithEncMemberRule>);
+	static_assert(!mpp::has_enc_rule_v<WithDecMemberRule>);
+	static_assert(mpp::has_dec_rule_v<WithDecMemberRule>);
+
+	static_assert(mpp::has_enc_rule_v<WithMppSpecRule>);
+	static_assert(mpp::has_dec_rule_v<WithMppSpecRule>);
+	static_assert(mpp::has_enc_rule_v<WithEncSpecRule>);
+	static_assert(!mpp::has_dec_rule_v<WithEncSpecRule>);
+	static_assert(!mpp::has_enc_rule_v<WithDecSpecRule>);
+	static_assert(mpp::has_dec_rule_v<WithDecSpecRule>);
+
+	fail_unless(&mpp::get_enc_rule<WithMppMemberRule>() ==
+		    &WithMppMemberRule::mpp);
+	fail_unless(&mpp::get_dec_rule<WithMppMemberRule>() ==
+		    &WithMppMemberRule::mpp);
+	fail_unless(&mpp::get_enc_rule<WithEncMemberRule>() ==
+		    &WithEncMemberRule::mpp_enc);
+	fail_unless(&mpp::get_dec_rule<WithDecMemberRule>() ==
+		    &WithDecMemberRule::mpp_dec);
+
+	fail_unless(&mpp::get_enc_rule<WithMppSpecRule>() ==
+		    &mpp_rule<WithMppSpecRule>::value);
+	fail_unless(&mpp::get_dec_rule<WithMppSpecRule>() ==
+		    &mpp_rule<WithMppSpecRule>::value);
+	fail_unless(&mpp::get_enc_rule<WithEncSpecRule>() ==
+		    &mpp_enc_rule<WithEncSpecRule>::value);
+	fail_unless(&mpp::get_dec_rule<WithDecSpecRule>() ==
+		    &mpp_dec_rule<WithDecSpecRule>::value);
+}
+
 int main()
 {
 	test_under_ints();
 	test_bswap();
 	test_type_visual();
 	test_basic();
+	test_class_rules();
 }

--- a/test/EncDecTest.cpp
+++ b/test/EncDecTest.cpp
@@ -425,8 +425,8 @@ test_basic()
 		std::forward_as_tuple(10, true, 11, "val",
 				      12, std::make_tuple(1, 2, 3))));
 	// String keys.
-	mpp::encode(buf, mpp::as_map(std::make_tuple("key1", "val1",
-						     "key2", "val2")));
+	mpp::encode(buf, std::make_tuple(std::make_pair("key1", "val1"),
+					 std::make_pair("key2", "val2")));
 	// Mixed keys.
 	mpp::encode(buf, mpp::as_map(std::make_tuple(1, "val1",
 						     "key2", "val2")));

--- a/test/TraitsUnitTest.cpp
+++ b/test/TraitsUnitTest.cpp
@@ -386,7 +386,7 @@ struct tuple_element<I, TupleClass> { using type = std::tuple_element_t<I, std::
 }
 
 void
-test_unversal_access()
+test_universal_access()
 {
 	TEST_INIT(0);
 
@@ -494,6 +494,19 @@ test_unversal_access()
 	fail_unless(tnt::get<0>(tc) == 5);
 	tnt::get<float>(tc) = 3.5f;
 	fail_unless(tnt::get<float>(tc) == 3.5f);
+
+	using X = std::tuple<int>;
+	using CX = const X;
+	X x;
+	CX cx;
+	static_assert(std::is_same_v<int&, decltype(tnt::get<int>(x))>);
+	static_assert(std::is_same_v<const int&, decltype(tnt::get<int>(cx))>);
+	static_assert(std::is_same_v<int&&, decltype(tnt::get<int>(X{}))>);
+	static_assert(std::is_same_v<const int&&, decltype(tnt::get<int>(CX{}))>);
+	static_assert(std::is_same_v<int&, decltype(tnt::get<0>(x))>);
+	static_assert(std::is_same_v<const int&, decltype(tnt::get<0>(cx))>);
+	static_assert(std::is_same_v<int&&, decltype(tnt::get<0>(X{}))>);
+	static_assert(std::is_same_v<const int&&, decltype(tnt::get<0>(CX{}))>);
 }
 
 struct CustomPair {
@@ -1034,7 +1047,7 @@ int main()
 	test_integer_traits();
 	test_c_traits();
 	test_integral_constant_traits();
-	test_unversal_access();
+	test_universal_access();
 	test_tuple_pair_traits();
 	test_variant_traits();
 	test_optional_traits();


### PR DESCRIPTION
Now it became possible to pass an object of any class to
mpp::encode and mpp::decode if a co/dec rule is supplied.

There are two ways to specify a rule for a particular class:
* through static member of the class, that is `mpp` member for
  ecoding/decoding, `mpp_enc` for encoding only and `mpp_dec` fo
  decoding only.
* via partial specialization of special global class, that is
  `mpp_rule` for ecoding/decoding, `mpp_enc_rule` for ecoding and
  `mpp_dec_rule` for decoding. In any of these cases a static
  member `value` is expected in the specialization.

In any case the value of the encoding rule must be a constexpr
expression that could contain any values, including standard
aggregates like std::tuple and pointers to members of the class
that must be encoded/decoded.

Note that one can specify one rule for encoding/decoding as well
as different rules for encoding and decoding.

Examples:

```
struct IntegerWrapper {
	int i;
	static constexpr auto mpp = &IntegerWrapper::i;
};
```
An object of such a class will be encoded/decoded as one integer
(MP_INT) value.

```
struct Triplet {
	int a;
	double b;
	std::string c;
};

template <>
struct mpp_rule<Triplet> {
	static constexpr auto value = std::make_tuple(&Triplet::a,
						      &Triplet::b,
						      &Triplet::c);
};
```
An object of this class will be encoded/decoded as array (MP_ARR)
of three values - a, b, c - with the corresponding types.

```
struct Error {
	int code = 0;
	std::string descr;

	static constexpr auto mpp = std::make_tuple(
		std::make_pair(0, &Error::code),
		std::make_pair(1, &Error::descr));
};
```
This error will be encoded/decoded as map (MP_MAP) with integer
keys (0, 1) and corresponding values (code, descr).