### PR TITLE
Build: create `tntcxx::tntcxx` interface library target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,14 +9,30 @@ ENDIF()
 MESSAGE(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 FIND_PACKAGE (benchmark QUIET)
 
-SET(COMMON_LIB ev)
+SET(CMAKE_CXX_STANDARD 17)
+SET(CMAKE_C_STANDARD 11)
+ADD_COMPILE_OPTIONS(-Wall -Wextra -Werror)
+
+ADD_LIBRARY(tntcxx INTERFACE)
+ADD_LIBRARY(tntcxx::tntcxx ALIAS tntcxx)
+TARGET_INCLUDE_DIRECTORIES(tntcxx INTERFACE .)
+TARGET_INCLUDE_DIRECTORIES(tntcxx INTERFACE ./src)
+
+ADD_LIBRARY(ev STATIC third_party/libev/ev.c)
+TARGET_COMPILE_DEFINITIONS(ev PRIVATE EV_STANDALONE=1)
+TARGET_COMPILE_OPTIONS(ev PRIVATE -w)
+TARGET_INCLUDE_DIRECTORIES(ev PUBLIC ./third_party/libev)
+
+TARGET_LINK_LIBRARIES(tntcxx INTERFACE ev)
+
+SET(COMMON_LIB tntcxx ev)
 
 # OpenSSL
 IF (TNTCXX_ENABLE_SSL)
 FIND_PACKAGE(OpenSSL)
 IF (OPENSSL_FOUND)
     MESSAGE(STATUS "OpenSSL ${OPENSSL_VERSION} found")
-    INCLUDE_DIRECTORIES(${OPENSSL_INCLUDE_DIR})
+    TARGET_INCLUDE_DIRECTORIES(tntcxx INTERFACE ${OPENSSL_INCLUDE_DIR})
 ELSE()
     MESSAGE(FATAL_ERROR "Could NOT find OpenSSL development files (libssl-dev/openssl-devel package)")
 ENDIF()
@@ -30,17 +46,6 @@ ENDIF()
 SET(COMMON_LIB ${COMMON_LIB} ${OPENSSL_LIBRARIES})
 
 ENDIF() # IF (TNTCXX_ENABLE_SSL)
-
-SET(CMAKE_CXX_STANDARD 17)
-SET(CMAKE_C_STANDARD 11)
-ADD_COMPILE_OPTIONS(-Wall -Wextra -Werror)
-
-INCLUDE_DIRECTORIES(.)
-INCLUDE_DIRECTORIES(./src)
-INCLUDE_DIRECTORIES(./third_party/libev)
-ADD_LIBRARY(ev STATIC third_party/libev/ev.c)
-TARGET_COMPILE_DEFINITIONS(ev PRIVATE EV_STANDALONE=1)
-TARGET_COMPILE_OPTIONS(ev PRIVATE -w)
 
 # Compensating the lack of PROJECT_IS_TOP_LEVEL for older cmake version.
 IF (CMAKE_VERSION VERSION_LESS 3.21)
@@ -103,50 +108,62 @@ ENDFUNCTION()
 
 TNTCXX_TEST(NAME MempoolUnit.test TYPE ctest
             SOURCES src/Utils/Mempool.hpp test/MempoolUnitTest.cpp
+            LIBRARIES ${COMMON_LIB}
 )
 
 TNTCXX_TEST(NAME CStrUnit.test TYPE ctest
             SOURCES src/Utils/CStr.hpp test/CStrUnitTest.cpp
+            LIBRARIES ${COMMON_LIB}
 )
 
 TNTCXX_TEST(NAME CommonUnit.test TYPE ctest
             SOURCES src/Utils/Common.hpp test/CommonUnitTest.cpp
+            LIBRARIES ${COMMON_LIB}
 )
 
 TNTCXX_TEST(NAME TraitsUnit.test TYPE ctest
             SOURCES src/Utils/Traits.hpp test/TraitsUnitTest.cpp
+            LIBRARIES ${COMMON_LIB}
 )
 
 TNTCXX_TEST(NAME RefVectorUnit.test TYPE ctest
             SOURCES src/Utils/RefVector.hpp test/RefVectorUnitTest.cpp
+            LIBRARIES ${COMMON_LIB}
 )
 
 TNTCXX_TEST(NAME ItrRangeUnit.test TYPE ctest
             SOURCES src/Utils/ItrRange.hpp test/ItrRangeUnitTest.cpp
+            LIBRARIES ${COMMON_LIB}
 )
 
 TNTCXX_TEST(NAME Base64Unit.test TYPE ctest
             SOURCES src/Utils/Base64.hpp test/Base64UnitTest.cpp
+            LIBRARIES ${COMMON_LIB}
 )
 
 TNTCXX_TEST(NAME BufferUnit.test TYPE ctest
             SOURCES src/Buffer/Buffer.hpp test/BufferUnitTest.cpp
+            LIBRARIES ${COMMON_LIB}
 )
 
 TNTCXX_TEST(NAME RingUnit.test TYPE ctest
             SOURCES src/Utils/Ring.hpp test/RingUnitTest.cpp
+            LIBRARIES ${COMMON_LIB}
 )
 
 TNTCXX_TEST(NAME ListUnit.test TYPE ctest
             SOURCES src/Utils/List.hpp test/ListUnitTest.cpp
+            LIBRARIES ${COMMON_LIB}
 )
 
 TNTCXX_TEST(NAME RulesUnit.test TYPE ctest
             SOURCES src/mpp/Rules.hpp test/RulesUnitTest.cpp
+            LIBRARIES ${COMMON_LIB}
 )
 
 TNTCXX_TEST(NAME EncDecUnit.test TYPE ctest
             SOURCES src/mpp/mpp.hpp test/EncDecTest.cpp
+            LIBRARIES ${COMMON_LIB}
 )
 
 TNTCXX_TEST(NAME Client.test TYPE ctest

--- a/README.md
+++ b/README.md
@@ -39,33 +39,27 @@ different ways:
     approach doesn't have the limitations of the other methods.
 
 The last of the above methods is implemented with a small piece of CMake code 
-that downloads and pulls the tntcxx code into the main build.
-
-Just add the following snippet to your CMakeLists.txt:
+that downloads and pulls the tntcxx code into the main build. Just add the 
+following snippet to your CMakeLists.txt:
 ```cmake
 include(FetchContent)
-FetchContent_Declare(tntcxx
+FetchContent_Declare(
+  tntcxx
   GIT_REPOSITORY https://github.com/tarantool/tntcxx.git
 )
-FetchContent_GetProperties(tntcxx)
-if(NOT tntcxx_POPULATED)
-    FetchContent_Populate(tntcxx)
-endif()
+FetchContent_MakeAvailable(tntcxx)
 ```
 
-2. You can then use the following CMake snippet to incorporate tntcxx into your 
-CMake project:
+After obtaining tntcxx sources using the rest of the methods, you can use the 
+following CMake command to incorporate tntcxx into your CMake project:
 ```cmake
-add_subdirectory(${TNTCXX_SOURCE_DIR} ${TNTCXX_BINARY_DIR})
+add_subdirectory(${TNTCXX_SOURCE_DIR})
+```
 
-target_link_libraries(${PROJECT_NAME}
-    PRIVATE ev
-)
-
-target_include_directories(${PROJECT_NAME}
-    PRIVATE ${tntcxx_SOURCE_DIR}
-    PRIVATE ${tntcxx_SOURCE_DIR}/third_party/libev
-)
+2. Now simply link against the tntcxx::tntcxx target as needed:
+```cmake
+add_executable(example example.cpp)
+target_link_libraries(example tntcxx::tntcxx)
 ```
 
 ##### Running tntcxx Tests with CMake


### PR DESCRIPTION
Currently, using our library in one's CMake project is a mess. It requires manually linking against our dependencies and manually adding include directories.

To fix this, let's add a `tntcxx::tntcxx` interface target, linking against would be enough to use our library in one's CMake project.

Closes #44