### PR TITLE
Old optional

### DIFF
--- a/src/mpp/Constants.hpp
+++ b/src/mpp/Constants.hpp
@@ -203,6 +203,12 @@ struct family_sequence {
 	}
 };
 
+template <compact::Family NEW_FAMILY, compact::Family ...FAMILY>
+static constexpr auto family_sequence_populate(struct family_sequence<FAMILY...>)
+{
+	return family_sequence<NEW_FAMILY, FAMILY...>{};
+}
+
 template <compact::Family ...FAMILY>
 std::ostream&
 operator<<(std::ostream& strm, family_sequence<FAMILY...>)

--- a/src/mpp/Dec.hpp
+++ b/src/mpp/Dec.hpp
@@ -246,8 +246,12 @@ struct Resolver {
 		}
 	}
 
+	/**
+	 * The method is used to get the container which contains the value the
+	 * path points to.
+	 */
 	template <class... T>
-	static constexpr auto&& prev(T... t)
+	static constexpr auto&& parent_container(T... t)
 	{
 		return unwrap(Resolver<I - 1, P...>::get(t...));
 	}
@@ -262,13 +266,13 @@ struct Resolver {
 		} else if constexpr (TYPE == PIT_DYN_POS) {
 			constexpr size_t ARG_POS = dyn_arg_pos();
 			uint64_t arg = std::get<ARG_POS>(std::tie(t...));
-			return std::data(prev(t...))[arg >> 32];
+			return std::data(parent_container(t...))[arg >> 32];
 		} else if constexpr (TYPE == PIT_DYN_BACK) {
-			return prev(t...).back();
+			return parent_container(t...).back();
 		} else if constexpr (TYPE == PIT_DYN_ADD) {
-			return prev(t...);
+			return parent_container(t...);
 		} else if constexpr (TYPE == PIT_DYN_KEY) {
-			return prev(t...);
+			return parent_container(t...);
 		} else {
 			static_assert(tnt::always_false_v<T...>);
 		}

--- a/src/mpp/Enc.hpp
+++ b/src/mpp/Enc.hpp
@@ -544,6 +544,12 @@ encode(CONT &cont, tnt::CStr<C...> prefix,
 	} if constexpr(mpp::has_enc_rule_v<T>) {
 		const auto& rule = mpp::get_enc_rule<T>();
 		return encode(cont, prefix, ais, subst(rule, t), more...);
+	} else if constexpr(tnt::is_optional_v<U>) {
+		static_assert(!is_wrapped_family_v<T> && !is_wrapped_raw_v<T>);
+		if (u.has_value())
+			return encode(cont, prefix, ais, u.value(), more...);
+		else
+			return encode(cont, prefix, ais, nullptr, more...);
 	} else if constexpr(is_wrapped_raw_v<T>) {
 		if constexpr(std::is_base_of_v<ChildrenTag, U>) {
 			using V = typename U::type;

--- a/test/EncDecTest.cpp
+++ b/test/EncDecTest.cpp
@@ -1256,7 +1256,8 @@ test_optional()
 	bool ok;
 
 	TEST_CASE("number");
-	mpp::encode(buf, 100, nullptr);
+	mpp::encode(buf, std::optional<int>(100), std::optional<int>(),
+		    std::optional<int>(42));
 
 	auto run = buf.begin<true>();
 	std::optional<int> opt_num;
@@ -1269,11 +1270,18 @@ test_optional()
 	fail_unless(ok);
 	fail_unless(!opt_num.has_value());
 
+	ok = mpp::decode(run, opt_num);
+	fail_unless(ok);
+	fail_unless(opt_num.has_value());
+	fail_unless(opt_num.value() == 42);
+
 	buf.flush();
 
 	TEST_CASE("containers with numbers");
 	int null_idx = 4;
-	mpp::encode(buf, mpp::as_arr(std::forward_as_tuple(0, 1, 2, 3, nullptr, 5)));
+	mpp::encode(buf, std::make_optional(mpp::as_arr(
+		std::forward_as_tuple(0, std::make_optional(1), 2, 3, std::optional<int>(), 5)
+	)));
 	mpp::encode(buf, nullptr);
 	std::vector<std::optional<int>> opt_num_arr;
 	std::set<std::optional<int>> opt_num_set;
@@ -1345,7 +1353,7 @@ test_optional()
 	TEST_CASE("objects");
 	Body wr;
 	wr.gen();
-	mpp::encode(buf, wr, nullptr);
+	mpp::encode(buf, std::optional<Body>(wr), std::optional<Body>());
 
 	run = buf.begin<true>();
 	std::optional<Body> rd;


### PR DESCRIPTION
The patch populates `mpp::encode` and `mpp::decode` functions with optional objects support. An empty optional is encoded as `MP_NIL`, and `MP_NIL` is decoded as an empty optional. Otherwise, underlying objects are encoded/decoded just like without optional.