### PR TITLE
Support optional in encoder and decoder

### DIFF
--- a/src/mpp/Constants.hpp
+++ b/src/mpp/Constants.hpp
@@ -203,6 +203,12 @@ struct family_sequence {
 	}
 };
 
+template <compact::Family NEW_FAMILY, compact::Family ...FAMILY>
+static constexpr auto family_sequence_populate(struct family_sequence<FAMILY...>)
+{
+	return family_sequence<NEW_FAMILY, FAMILY...>{};
+}
+
 template <compact::Family ...FAMILY>
 std::ostream&
 operator<<(std::ostream& strm, family_sequence<FAMILY...>)

--- a/src/mpp/Dec.hpp
+++ b/src/mpp/Dec.hpp
@@ -82,6 +82,8 @@ constexpr auto detectFamily()
 		      "Can't decode to constant type");
 	if constexpr (is_wrapped_family_v<T>) {
 		return family_sequence<T::family>{};
+	} else if constexpr (has_dec_rule_v<U>) {
+		return detectFamily<decltype(get_dec_rule<U>())>();
 	} else if constexpr (std::is_same_v<U, std::nullptr_t>) {
 		return family_sequence<compact::MP_NIL>{};
 	} else if constexpr (std::is_same_v<U, bool>) {
@@ -853,7 +855,7 @@ constexpr enum path_item_type get_next_arr_item_type()
 template <class ARR, enum path_item_type TYPE>
 constexpr size_t get_next_arr_static_size()
 {
-	if constexpr (TYPE <= PIT_STADYN)
+	if constexpr (TYPE <= PIT_STADYN && TYPE != PIT_BAD)
 		return tnt::tuple_size_v<ARR>;
 	else
 		return 0;

--- a/src/mpp/Enc.hpp
+++ b/src/mpp/Enc.hpp
@@ -544,6 +544,12 @@ encode(CONT &cont, tnt::CStr<C...> prefix,
 	} if constexpr(mpp::has_enc_rule_v<T>) {
 		const auto& rule = mpp::get_enc_rule<T>();
 		return encode(cont, prefix, ais, subst(rule, t), more...);
+	} else if constexpr(tnt::is_optional_v<U>) {
+		static_assert(!is_wrapped_family_v<T> && !is_wrapped_raw_v<T>);
+		if (u.has_value())
+			return encode(cont, prefix, ais, u.value(), more...);
+		else
+			return encode(cont, prefix, ais, nullptr, more...);
 	} else if constexpr(is_wrapped_raw_v<T>) {
 		if constexpr(std::is_base_of_v<ChildrenTag, U>) {
 			using V = typename U::type;

--- a/test/EncDecTest.cpp
+++ b/test/EncDecTest.cpp
@@ -1256,7 +1256,8 @@ test_optional()
 	bool ok;
 
 	TEST_CASE("number");
-	mpp::encode(buf, 100, nullptr);
+	mpp::encode(buf, std::optional<int>(100), std::optional<int>(),
+		    std::optional<int>(42));
 
 	auto run = buf.begin<true>();
 	std::optional<int> opt_num;
@@ -1269,11 +1270,18 @@ test_optional()
 	fail_unless(ok);
 	fail_unless(!opt_num.has_value());
 
+	ok = mpp::decode(run, opt_num);
+	fail_unless(ok);
+	fail_unless(opt_num.has_value());
+	fail_unless(opt_num.value() == 42);
+
 	buf.flush();
 
 	TEST_CASE("containers with numbers");
 	int null_idx = 4;
-	mpp::encode(buf, mpp::as_arr(std::forward_as_tuple(0, 1, 2, 3, nullptr, 5)));
+	mpp::encode(buf, std::make_optional(mpp::as_arr(
+		std::forward_as_tuple(0, std::make_optional(1), 2, 3, std::optional<int>(), 5)
+	)));
 	mpp::encode(buf, nullptr);
 	std::vector<std::optional<int>> opt_num_arr;
 	std::set<std::optional<int>> opt_num_set;
@@ -1345,7 +1353,7 @@ test_optional()
 	TEST_CASE("objects");
 	Body wr;
 	wr.gen();
-	mpp::encode(buf, wr, nullptr);
+	mpp::encode(buf, std::optional<Body>(wr), std::optional<Body>());
 
 	run = buf.begin<true>();
 	std::optional<Body> rd;

--- a/test/EncDecTest.cpp
+++ b/test/EncDecTest.cpp
@@ -1109,6 +1109,11 @@ struct IntegerWrapper {
 		return i == that.i;
 	}
 
+	bool operator<(const IntegerWrapper& that) const
+	{
+		return i < that.i;
+	}
+
 	static constexpr auto mpp = &IntegerWrapper::i;
 };
 
@@ -1127,6 +1132,11 @@ struct Triplet {
 	bool operator==(const Triplet& that) const
 	{
 		return std::tie(a, b, c) == std::tie(that.a, that.b, that.c);
+	}
+
+	bool operator<(const Triplet& that) const
+	{
+		return std::tie(a, b, c) < std::tie(that.a, that.b, that.c);
 	}
 };
 
@@ -1150,6 +1160,11 @@ struct Error {
 	bool operator==(const Error& that) const
 	{
 		return std::tie(code, descr) == std::tie(that.code, that.descr);
+	}
+
+	bool operator<(const Error& that) const
+	{
+		return std::tie(code, descr) < std::tie(that.code, that.descr);
 	}
 
 	static constexpr auto mpp = std::make_tuple(
@@ -1181,6 +1196,12 @@ struct Body {
 		       std::tie(that.str, that.num, that.triplets, that.errors);
 	}
 
+	bool operator<(const Body& that) const
+	{
+		return std::tie(str, num, triplets, errors) <
+		       std::tie(that.str, that.num, that.triplets, that.errors);
+	}
+
 	static constexpr auto mpp = std::make_tuple(
 		std::make_pair(0, &Body::str),
 		std::make_pair(1, &Body::num),
@@ -1197,9 +1218,11 @@ test_object_codec()
 	Buf_t buf;
 
 	Body wr, rd;
+	std::set<Body> rds;
 	wr.gen();
 
 	mpp::encode(buf, wr);
+	mpp::encode(buf, std::forward_as_tuple(wr));
 
 	for (auto itr = buf.begin(); itr != buf.end(); ++itr) {
 		char c = itr.get<uint8_t>();
@@ -1214,8 +1237,11 @@ test_object_codec()
 
 	auto itr = buf.begin();
 	mpp::decode(itr, rd);
-
 	fail_unless(rd == wr);
+
+	mpp::decode(itr, rds);
+	fail_unless(rds.count(wr) > 0);
+
 	fail_unless(itr == buf.end());
 }
 

--- a/test/EncDecTest.cpp
+++ b/test/EncDecTest.cpp
@@ -34,6 +34,7 @@
 #include <set>
 #include <map>
 #include <vector>
+#include <optional>
 
 #include "Utils/Helpers.hpp"
 #include "Utils/RefVector.hpp"
@@ -1245,6 +1246,198 @@ test_object_codec()
 	fail_unless(itr == buf.end());
 }
 
+static void
+test_optional()
+{
+	TEST_INIT(0);
+
+	using Buf_t = tnt::Buffer<16 * 1024>;
+	Buf_t buf;
+	bool ok;
+
+	TEST_CASE("number");
+	mpp::encode(buf, 100, nullptr);
+
+	auto run = buf.begin<true>();
+	std::optional<int> opt_num;
+	ok = mpp::decode(run, opt_num);
+	fail_unless(ok);
+	fail_unless(opt_num.has_value());
+	fail_unless(opt_num.value() == 100);
+
+	ok = mpp::decode(run, opt_num);
+	fail_unless(ok);
+	fail_unless(!opt_num.has_value());
+
+	buf.flush();
+
+	TEST_CASE("containers with numbers");
+	int null_idx = 4;
+	mpp::encode(buf, mpp::as_arr(std::forward_as_tuple(0, 1, 2, 3, nullptr, 5)));
+	mpp::encode(buf, nullptr);
+	std::vector<std::optional<int>> opt_num_arr;
+	std::set<std::optional<int>> opt_num_set;
+	std::optional<std::vector<std::optional<int>>> opt_num_opt_arr;
+	std::optional<std::set<std::optional<int>>> opt_num_opt_set;
+
+	run = buf.begin<true>();
+	ok = mpp::decode(run, opt_num_arr);
+	fail_unless(ok);
+	fail_unless(opt_num_arr.size() == 6);
+	for (int i = 0; i < 6; i++) {
+		if (i == null_idx) {
+			fail_unless(!opt_num_arr[i].has_value());
+			continue;
+		}
+		fail_unless(opt_num_arr[i].has_value());
+		fail_unless(opt_num_arr[i].value() == i);
+	}
+
+	run = buf.begin<true>();
+	ok = mpp::decode(run, opt_num_set);
+	fail_unless(ok);
+	fail_unless(opt_num_set.size() == 6);
+	for (int i = 0; i < 6; i++) {
+		if (i == null_idx) {
+			fail_unless(opt_num_set.count(i) == 0);
+			fail_unless(opt_num_set.count(std::nullopt) == 1);
+			continue;
+		}
+		fail_unless(opt_num_set.count(i) > 0);
+	}
+
+	run = buf.begin<true>();
+	ok = mpp::decode(run, opt_num_opt_arr);
+	fail_unless(ok);
+	fail_unless(opt_num_opt_arr.has_value());
+	fail_unless(opt_num_opt_arr->size() == 6);
+	for (int i = 0; i < 6; i++) {
+		if (i == null_idx) {
+			fail_unless(!opt_num_opt_arr.value()[i].has_value());
+			continue;
+		}
+		fail_unless(opt_num_opt_arr.value()[i].has_value());
+		fail_unless(opt_num_opt_arr.value()[i].value() == i);
+	}
+	ok = mpp::decode(run, opt_num_opt_arr);
+	fail_unless(ok);
+	fail_unless(!opt_num_opt_arr.has_value());
+
+	run = buf.begin<true>();
+	ok = mpp::decode(run, opt_num_opt_set);
+	fail_unless(ok);
+	fail_unless(opt_num_opt_set.has_value());
+	fail_unless(opt_num_opt_set->size() == 6);
+	for (int i = 0; i < 6; i++) {
+		if (i == null_idx) {
+			fail_unless(opt_num_opt_set->count(i) == 0);
+			fail_unless(opt_num_opt_set->count(std::nullopt) == 1);
+			continue;
+		}
+		fail_unless(opt_num_opt_set->count(i) > 0);
+	}
+	ok = mpp::decode(run, opt_num_opt_set);
+	fail_unless(ok);
+	fail_unless(!opt_num_opt_set.has_value());
+
+	buf.flush();
+
+	TEST_CASE("objects");
+	Body wr;
+	wr.gen();
+	mpp::encode(buf, wr, nullptr);
+
+	run = buf.begin<true>();
+	std::optional<Body> rd;
+	ok = mpp::decode(run, rd);
+	fail_unless(ok);
+	fail_unless(rd.has_value());
+	fail_unless(rd.value() == wr);
+
+	ok = mpp::decode(run, rd);
+	fail_unless(ok);
+	fail_unless(!rd.has_value());
+
+	buf.flush();
+
+	TEST_CASE("containers with objects");
+	std::vector<Body> wrs;
+	for (size_t i = 0; i < 3; i++) {
+		wrs.emplace_back();
+		wrs[i].gen();
+		wrs[i].str += std::to_string(i);
+	}
+	null_idx = 1;
+	mpp::encode(buf, mpp::as_arr(std::forward_as_tuple(wrs[0], nullptr, wrs[2])));
+	mpp::encode(buf, nullptr);
+	std::vector<std::optional<Body>> opt_body_arr;
+	std::set<std::optional<Body>> opt_body_set;
+	std::optional<std::vector<std::optional<Body>>> opt_body_opt_arr;
+	std::optional<std::set<std::optional<Body>>> opt_body_opt_set;
+
+	run = buf.begin<true>();
+	ok = mpp::decode(run, opt_body_arr);
+	fail_unless(ok);
+	fail_unless(opt_body_arr.size() == 3);
+	for (int i = 0; i < 3; i++) {
+		if (i == null_idx) {
+			fail_unless(!opt_body_arr[i].has_value());
+			continue;
+		}
+		fail_unless(opt_body_arr[i].has_value());
+		fail_unless(opt_body_arr[i].value() == wrs[i]);
+	}
+
+	run = buf.begin<true>();
+	ok = mpp::decode(run, opt_body_set);
+	fail_unless(ok);
+	fail_unless(opt_body_set.size() == 3);
+	fail_unless(opt_body_set.count(std::nullopt) == 1);
+	for (int i = 0; i < 3; i++) {
+		if (i == null_idx) {
+			fail_unless(opt_body_set.count(wrs[i]) == 0);
+			continue;
+		}
+		fail_unless(opt_body_set.count(wrs[i]) > 0);
+	}
+
+	run = buf.begin<true>();
+	ok = mpp::decode(run, opt_body_opt_arr);
+	fail_unless(ok);
+	fail_unless(opt_body_opt_arr.has_value());
+	fail_unless(opt_body_opt_arr->size() == 3);
+	for (int i = 0; i < 3; i++) {
+		if (i == null_idx) {
+			fail_unless(!opt_body_opt_arr.value()[i].has_value());
+			continue;
+		}
+		fail_unless(opt_body_opt_arr.value()[i].has_value());
+		fail_unless(opt_body_opt_arr.value()[i].value() == wrs[i]);
+	}
+	ok = mpp::decode(run, opt_body_opt_arr);
+	fail_unless(ok);
+	fail_unless(!opt_body_opt_arr.has_value());
+
+	run = buf.begin<true>();
+	ok = mpp::decode(run, opt_body_opt_set);
+	fail_unless(ok);
+	fail_unless(opt_body_opt_set.has_value());
+	fail_unless(opt_body_opt_set->size() == 3);
+	fail_unless(opt_body_opt_set->count(std::nullopt) == 1);
+	for (int i = 0; i < 3; i++) {
+		if (i == null_idx) {
+			fail_unless(opt_body_opt_set->count(wrs[i]) == 0);
+			continue;
+		}
+		fail_unless(opt_body_opt_set->count(wrs[i]) > 0);
+	}
+	ok = mpp::decode(run, opt_body_opt_set);
+	fail_unless(ok);
+	fail_unless(!opt_body_opt_set.has_value());
+
+	buf.flush();
+}
+
 int main()
 {
 	test_under_ints();
@@ -1253,4 +1446,5 @@ int main()
 	test_basic();
 	test_class_rules();
 	test_object_codec();
+	test_optional();
 }


### PR DESCRIPTION
The patch populates mpp::encode and mpp::decode functions with optional objects support. An empty optional is encoded as MP_NIL, and MP_NIL is decoded as an empty optional. Otherwise, underlying objects are encoded/decoded just like without optional.