### PR TITLE
Dec: allow to save iterator to value instead of decoding

### DIFF
--- a/src/Utils/Traits.hpp
+++ b/src/Utils/Traits.hpp
@@ -58,6 +58,7 @@
  * tuple_iseq
  * is_tuplish_v (standard (tuple, array, pair) + bounded array)
  * is_pairish_v
+ * is_pairish_of_v
  * is_tuplish_of_pairish_v
  * is_variant_v
  * is_optional_v
@@ -488,6 +489,24 @@ struct is_pairish_h<T, std::void_t<
 
 template <class T>
 constexpr bool is_pairish_v = details::is_pairish_h<std::remove_cv_t<T>>::value;
+
+namespace details {
+template <class T, class V1, class V2, class _ = void>
+struct is_pairish_of_h : std::false_type {};
+
+template <class T, class V1, class V2>
+struct is_pairish_of_h<T, V1, V2, std::void_t<
+	std::enable_if_t<is_pairish_v<T>, void>,
+	std::enable_if_t<std::is_same_v<std::remove_cv_t<decltype(std::declval<T&>().first)>, V1>, void>,
+	std::enable_if_t<std::is_same_v<std::remove_cv_t<decltype(std::declval<T&>().second)>, V2>, void>>>
+: std::true_type {};
+} //namespace details {
+
+template <class T, class V1, class V2>
+constexpr bool is_pairish_of_v = details::is_pairish_of_h<
+	std::remove_cv_t<T>,
+	std::remove_cv_t<V1>,
+	std::remove_cv_t<V2>>::value;
 
 /**
  * Check whether the type is compatible with std::tuple (see is_tuplish_v) and

--- a/test/TraitsUnitTest.cpp
+++ b/test/TraitsUnitTest.cpp
@@ -582,6 +582,24 @@ test_tuple_pair_traits()
 	static_assert(!tnt::is_pairish_v<Test>);
 	static_assert(!tnt::is_pairish_v<const_int>);
 
+	static_assert(tnt::is_pairish_of_v<std::pair<int, bool>, int, bool>);
+	static_assert(!tnt::is_pairish_of_v<std::pair<int, bool>, bool, int>);
+	static_assert(!tnt::is_pairish_of_v<std::pair<int, bool>, int, char>);
+	static_assert(!tnt::is_pairish_of_v<std::pair<int, bool>, char, bool>);
+	static_assert(tnt::is_pairish_of_v<const volatile std::pair<int, int>, int, int>);
+	static_assert(tnt::is_pairish_of_v<std::pair<int&, float&&>, int&, float&&>);
+	static_assert(!tnt::is_pairish_of_v<const std::pair<int, int>&, int, int>);
+	static_assert(tnt::is_pairish_of_v<CustomPair, int, double>);
+	static_assert(tnt::is_pairish_of_v<const CustomPair, int, double>);
+	static_assert(!tnt::is_pairish_of_v<const CustomPair&, int, double>);
+
+	static_assert(!tnt::is_pairish_of_v<TupleClass, int, float>);
+	static_assert(!tnt::is_pairish_of_v<std::tuple<int, int>, int, int>);
+	static_assert(!tnt::is_pairish_of_v<Test, int, int>);
+	static_assert(!tnt::is_pairish_of_v<int, int, int>);
+	static_assert(!tnt::is_pairish_of_v<E, int, int>);
+	static_assert(!tnt::is_pairish_of_v<const_int, int, int>);
+
 	static_assert(tnt::is_tuplish_of_pairish_v<std::tuple<>>);
 	static_assert(!tnt::is_tuplish_of_pairish_v<std::tuple<int>>);
 	static_assert(tnt::is_tuplish_of_pairish_v<std::tuple<std::pair<int, int>>>);


### PR DESCRIPTION
The patch adds support of `mpp::as_raw` to new decoder. Wrapped value must be a pair of iterators (it can be wrapped to optional). When it is used, corresponding value is skipped but an iterator pointing to the value in buffer is saved. Also, one can pass `pair<it_t, it_t>` without `as_raw` tag.

NB: Encoder is not provided with `pair<it_t, it_t>` support in this patch - it will be later.