### PR TITLE
CI: build release workflows with RelWithDebInfo type

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,7 +20,7 @@ jobs:
           - macos-12
         build-type:
           - Debug
-          - ReleaseWithDebInfo
+          - RelWithDebInfo
     with:
       runs-on: ${{ matrix.runs-on }}
       build-type: ${{ matrix.runs-on }}
@@ -32,7 +32,7 @@ jobs:
       matrix:
         build-type:
           - Debug
-          - ReleaseWithDebInfo
+          - RelWithDebInfo
     with:
       runs-on: ubuntu-22.04
       build-type: ${{ matrix.build-type }}
@@ -48,7 +48,7 @@ jobs:
           - macos-12
         build-type:
           - Debug
-          - ReleaseWithDebInfo
+          - RelWithDebInfo
     with:
       runs-on: ${{ matrix.runs-on }}
       build-type: ${{ matrix.build-type }}

--- a/examples/Simple.cpp
+++ b/examples/Simple.cpp
@@ -65,6 +65,7 @@ decodeUserTuple(Data<BUFFER> &data)
 {
 	std::vector<UserTuple> results;
 	bool ok = data.decode(results);
+	(void)ok;
 	assert(ok);
 	return results;
 }


### PR DESCRIPTION
Accidentally, release workflows are built with ReleaseWithDebInfo. This build type is not valid - that's why NDEBUG is not set, and all workflows are built in Debug mode actually. Let's fix this mistake and all associated compilation errors along the way.