### PR TITLE
ci: fix valgrind workflow

### DIFF
--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Setup valgrind
         if: inputs.use-valgrind
-        run: sudo apt install -y valgrind
+        run: sudo apt update && sudo apt install -y valgrind
 
       - name: Build tntcxx
         uses: ./.github/actions/build-tntcxx


### PR DESCRIPTION
Valgrind runners fail to fetch valgrind from apt, so let's do apt upgrade before apt install - it solves the problem.