### PR TITLE
Build, CI: set up code formatting infrastructure

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,11 @@
+---
+Language: Cpp
+BasedOnStyle: WebKit
+Standard: c++17
+IndentWidth: 8
+UseTab: Always
+
+AccessModifierOffset: -8
+AlwaysBreakAfterReturnType: TopLevel
+PointerAlignment: Right
+ReferenceAlignment: Right

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[CMakeLists.txt]
+indent_style = space
+indent_size = 4
+
+[*.cmake]
+indent_style = space
+indent_size = 4
+
+[*.lua]
+indent_style = space
+indent_size = 4
+
+[*.{h,hpp,c,cc,cpp}]
+indent_style = tab
+tab_width = 8

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+# Redirect output to stderr.
+exec 1>&2
+
+output=$(git clang-format --diff --staged)
+if [[ "$output" != "" && "$output" != "no modified files to format" ]]; then
+  echo Code formatting changed some files, please review.
+  exit 1
+fi

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,27 @@
+name: Linting
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  code-formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone tntcxx
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up clang-format
+        run: sudo apt install -y clang-format
+        shell: bash
+      - name: Run clang-format
+        # Run clang-format on commits off the base branch of the pull request.
+        run: |
+          output=$(git clang-format origin/${{ github.event.pull_request.base.ref }} --diff)
+          if [[ "$output" != "" && "$output" != "no modified files to format" ]]; then
+            echo "$output"
+            echo Code formatting changed some files, please review.
+            exit 1
+          fi
+        shell: bash


### PR DESCRIPTION
This patch sets up code formatting infrastructure. Supersedes #17.