### PR TITLE
Decoder: optimize decoding of optional and variant for scalar types

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,6 +8,7 @@ UseTab: Always
 AccessModifierOffset: -8
 AlignAfterOpenBracket: Align
 AlwaysBreakAfterReturnType: TopLevel
+ColumnLimit: 120
 ContinuationIndentWidth: 8
 Cpp11BracedListStyle: true
 SpaceInEmptyBlock: false

--- a/src/mpp/Rules.hpp
+++ b/src/mpp/Rules.hpp
@@ -134,6 +134,8 @@ struct BaseRule {
 	static constexpr uint32_t children_multiplier =
 		FAMILY == compact::MP_ARR ? 1 :
 		FAMILY == compact::MP_MAP ? 2 : 0;
+	// The encoded object can be read by value.
+	static constexpr bool is_readable_by_value = !has_data && !has_ext && !has_children;
 	// The rule has simplex form.
 	static constexpr bool has_simplex = FAMILY == compact::MP_NIL ||
 					    FAMILY == compact::MP_IGNR ||


### PR DESCRIPTION
This patch optimizes the decoding of optional and variant values for scalar types.

Closes #84