### PR TITLE
Alyapunov/cleanup and impovement

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,16 +1,73 @@
 ---
 Language: Cpp
-BasedOnStyle: WebKit
+BasedOnStyle: LLVM
 Standard: c++17
-IndentWidth: 8
-UseTab: Always
-
-AccessModifierOffset: -8
-AlignAfterOpenBracket: Align
-AlwaysBreakAfterReturnType: TopLevel
 ColumnLimit: 120
+
+# Tabs and indents
+IndentWidth: 8
 ContinuationIndentWidth: 8
+ConstructorInitializerIndentWidth: 8
+AccessModifierOffset: -8
+UseTab: Always
+TabWidth: 8
+AlignAfterOpenBracket: Align
+AlignOperands: Align
+AlignConsecutiveAssignments: None
+NamespaceIndentation: None
+
+
+# Spaces
 Cpp11BracedListStyle: true
-SpaceInEmptyBlock: false
 PointerAlignment: Right
-ReferenceAlignment: Right
+ReferenceAlignment: Left
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+FixNamespaceComments: true
+
+# Wrapping and braces
+AlwaysBreakAfterReturnType: TopLevel
+AlwaysBreakTemplateDeclarations: Yes
+
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Always
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+
+BreakInheritanceList: AfterColon
+BreakStringLiterals: true
+BreakConstructorInitializers: AfterColon
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: false
+  AfterUnion: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: true

--- a/src/Buffer/Buffer.hpp
+++ b/src/Buffer/Buffer.hpp
@@ -675,8 +675,6 @@ template <size_t N, class allocator>
 void
 Buffer<N, allocator>::write(WData data)
 {
-	assert(data.size != 0);
-
 	char *new_end = m_end + data.size;
 	if (TNT_LIKELY(isSameBlock(m_end, new_end))) {
 		// new_addr is still in block. just copy and advance.
@@ -1132,7 +1130,6 @@ template <bool LIGHT>
 void
 Buffer<N, allocator>::iterator_common<LIGHT>::write(WData data)
 {
-	assert(data.size > 0);
 	size_t left_in_block = N - (uintptr_t) m_position % N;
 	while (TNT_UNLIKELY(data.size >= left_in_block)) {
 		std::memcpy(m_position, data.data, left_in_block);
@@ -1238,7 +1235,6 @@ template <bool LIGHT>
 void
 Buffer<N, allocator>::iterator_common<LIGHT>::read(RData data)
 {
-	assert(data.size > 0);
 	/*
 	 * The same implementation as in ::set() method buf vice versa:
 	 * buffer and data sources are swapped.

--- a/src/mpp/Constants.hpp
+++ b/src/mpp/Constants.hpp
@@ -1,4 +1,3 @@
-#pragma once
 /*
  * Copyright 2010-2020, Tarantool AUTHORS, please see AUTHORS file.
  *
@@ -29,8 +28,9 @@
  * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
+#pragma once
 
-#include <iostream> // TODO - make output to iostream optional?
+#include <iostream>
 #include <variant>
 #include <limits>
 
@@ -51,42 +51,6 @@ enum Family : uint8_t {
 	MP_END
 };
 } // namespace compact {
-
-using FamilyUnder_t = uint32_t;
-enum Family : FamilyUnder_t {
-	MP_NIL  = 1u << compact::MP_NIL,
-	MP_IGNR = 1u << compact::MP_IGNR,
-	MP_BOOL = 1u << compact::MP_BOOL,
-	MP_INT  = 1u << compact::MP_INT,
-	MP_FLT  = 1u << compact::MP_FLT,
-	MP_STR  = 1u << compact::MP_STR,
-	MP_BIN  = 1u << compact::MP_BIN,
-	MP_ARR  = 1u << compact::MP_ARR,
-	MP_MAP  = 1u << compact::MP_MAP,
-	MP_EXT  = 1u << compact::MP_EXT,
-	MP_NUM = (1u << compact::MP_INT) | (1u << compact::MP_FLT),
-	MP_NONE = 0,
-	MP_ANY  = std::numeric_limits<FamilyUnder_t>::max(),
-};
-
-enum ReadError_t {
-	READ_ERROR_NEED_MORE,
-	READ_ERROR_BAD_MSGPACK,
-	READ_ERROR_WRONG_TYPE,
-	READ_ERROR_MAX_DEPTH_REACHED,
-	READ_ERROR_ABORTED_BY_USER,
-	READ_ERROR_END
-};
-
-enum ReadResult_t : FamilyUnder_t {
-	READ_SUCCESS = 0,
-	READ_NEED_MORE = 1u << READ_ERROR_NEED_MORE,
-	READ_BAD_MSGPACK = 1u << READ_ERROR_BAD_MSGPACK,
-	READ_WRONG_TYPE = 1u << READ_ERROR_WRONG_TYPE,
-	READ_MAX_DEPTH_REACHED = 1u << READ_ERROR_MAX_DEPTH_REACHED,
-	READ_ABORTED_BY_USER = 1u << READ_ERROR_ABORTED_BY_USER,
-	READ_RESULT_END
-};
 
 inline const char *FamilyName[] = {
 	"MP_NIL",
@@ -120,51 +84,6 @@ inline const char *FamilyHumanName[] = {
 };
 static_assert(std::size(FamilyHumanName) == compact::MP_END + 2, "Smth is forgotten");
 
-inline const char *ReadErrorName[] = {
-	"READ_ERROR_NEED_MORE",
-	"READ_ERROR_BAD_MSGPACK",
-	"READ_ERROR_WRONG_TYPE",
-	"READ_ERROR_MAX_DEPTH_REACHED",
-	"READ_ERROR_ABORTED_BY_USER",
-	"READ_ERROR_UNKNOWN",
-	"READ_SUCCESS",
-};
-static_assert(std::size(ReadErrorName) == READ_ERROR_END + 2, "Forgotten");
-
-inline constexpr Family
-operator|(Family a, Family b)
-{
-	return static_cast<Family>(static_cast<FamilyUnder_t>(a) |
-				   static_cast<FamilyUnder_t>(b));
-}
-
-inline constexpr Family
-operator&(Family a, Family b)
-{
-	return static_cast<Family>(static_cast<FamilyUnder_t>(a) &
-				   static_cast<FamilyUnder_t>(b));
-}
-
-inline constexpr ReadResult_t
-operator|(ReadResult_t a, ReadResult_t b)
-{
-	return static_cast<ReadResult_t>(static_cast<FamilyUnder_t>(a) |
-					 static_cast<FamilyUnder_t>(b));
-}
-
-inline constexpr ReadResult_t
-operator&(ReadResult_t a, ReadResult_t b)
-{
-	return static_cast<ReadResult_t>(static_cast<FamilyUnder_t>(a) &
-					 static_cast<FamilyUnder_t>(b));
-}
-
-inline constexpr ReadResult_t
-operator~(ReadResult_t a)
-{
-	return static_cast<ReadResult_t>(~static_cast<FamilyUnder_t>(a));
-}
-
 inline std::ostream&
 operator<<(std::ostream& strm, compact::Family t)
 {
@@ -172,27 +91,6 @@ operator<<(std::ostream& strm, compact::Family t)
 		return strm << FamilyName[compact::Family::MP_END]
 			    << "(" << static_cast<uint64_t>(t) << ")";
 	return strm << FamilyName[t];
-}
-
-inline std::ostream&
-operator<<(std::ostream& strm, Family t)
-{
-	if (t == MP_NONE)
-		return strm << FamilyName[compact::Family::MP_END + 1];
-	static_assert(sizeof(FamilyUnder_t) == sizeof(t), "Very wrong");
-	FamilyUnder_t base = t;
-	bool first = true;
-	do {
-		static_assert(sizeof(unsigned) == sizeof(t), "Wrong ctz");
-		unsigned part = __builtin_ctz(base);
-		base ^= 1u << part;
-		if (first)
-			first = false;
-		else
-			strm << "|";
-		strm << static_cast<compact::Family>(part);
-	} while (base != 0);
-	return strm;
 }
 
 template <compact::Family ...FAMILY>
@@ -203,7 +101,7 @@ struct family_sequence {
 	}
 };
 
-template <compact::Family NEW_FAMILY, compact::Family ...FAMILY>
+template <compact::Family NEW_FAMILY, compact::Family... FAMILY>
 static constexpr auto family_sequence_populate(struct family_sequence<FAMILY...>)
 {
 	return family_sequence<NEW_FAMILY, FAMILY...>{};
@@ -250,7 +148,7 @@ struct family_sequence_contains_h<NEEDLE> {
 	static constexpr bool value = false;
 };
 
-} //namespace details
+} // namespace details
 
 template <compact::Family NEEDLE, compact::Family ...HAYSTACK>
 static constexpr bool family_sequence_contains(family_sequence<HAYSTACK...>) {
@@ -268,40 +166,4 @@ operator<<(std::ostream& strm, family_sequence<FAMILY...>)
 	return strm;
 }
 
-inline std::ostream&
-operator<<(std::ostream& strm, ReadError_t t)
-{
-	if (t >= READ_ERROR_END)
-		return strm << ReadErrorName[READ_ERROR_END]
-			    << "(" << static_cast<uint64_t>(t) << ")";
-	return strm << ReadErrorName[t];
-}
-
-inline std::ostream&
-operator<<(std::ostream& strm, ReadResult_t t)
-{
-	if (t == READ_SUCCESS)
-		return strm << ReadErrorName[READ_ERROR_END + 1];
-	static_assert(sizeof(FamilyUnder_t) == sizeof(t), "Very wrong");
-	FamilyUnder_t base = t;
-	bool first = true;
-	do {
-		static_assert(sizeof(unsigned) == sizeof(t), "Wrong ctz");
-		unsigned part = __builtin_ctz(base);
-		base ^= 1u << part;
-		if (first)
-			first = false;
-		else
-			strm << "|";
-		strm << static_cast<ReadError_t>(part);
-	} while (base != 0);
-	return strm;
-}
-
-struct StrValue { uint32_t offset; uint32_t size; };
-struct BinValue { uint32_t offset; uint32_t size; };
-struct ArrValue { uint32_t offset; uint32_t size; };
-struct MapValue { uint32_t offset; uint32_t size; };
-struct ExtValue { int8_t type; uint8_t offset; uint32_t size; };
-
-} // namespace mpp {
+} // namespace mpp

--- a/src/mpp/Constants.hpp
+++ b/src/mpp/Constants.hpp
@@ -36,7 +36,6 @@
 
 namespace mpp {
 
-namespace compact {
 enum Family : uint8_t {
 	MP_NIL  /* = 0x00 */,
 	MP_IGNR  /* = 0x01 */,
@@ -50,7 +49,6 @@ enum Family : uint8_t {
 	MP_EXT  /* = 0x09 */,
 	MP_END
 };
-} // namespace compact {
 
 inline const char *FamilyName[] = {
 	"MP_NIL",
@@ -66,7 +64,7 @@ inline const char *FamilyName[] = {
 	"MP_BAD",
 	"MP_NONE"
 };
-static_assert(std::size(FamilyName) == compact::MP_END + 2, "Smth is forgotten");
+static_assert(std::size(FamilyName) == MP_END + 2, "Smth is forgotten");
 
 inline const char *FamilyHumanName[] = {
 	"nil",
@@ -82,18 +80,18 @@ inline const char *FamilyHumanName[] = {
 	"bad",
 	"none"
 };
-static_assert(std::size(FamilyHumanName) == compact::MP_END + 2, "Smth is forgotten");
+static_assert(std::size(FamilyHumanName) == MP_END + 2, "Smth is forgotten");
 
 inline std::ostream&
-operator<<(std::ostream& strm, compact::Family t)
+operator<<(std::ostream& strm, Family t)
 {
-	if (t >= compact::Family::MP_END)
-		return strm << FamilyName[compact::Family::MP_END]
+	if (t >= Family::MP_END)
+		return strm << FamilyName[Family::MP_END]
 			    << "(" << static_cast<uint64_t>(t) << ")";
 	return strm << FamilyName[t];
 }
 
-template <compact::Family ...FAMILY>
+template <Family ...FAMILY>
 struct family_sequence {
 	static constexpr std::size_t size() noexcept
 	{
@@ -101,13 +99,13 @@ struct family_sequence {
 	}
 };
 
-template <compact::Family NEW_FAMILY, compact::Family... FAMILY>
+template <Family NEW_FAMILY, Family... FAMILY>
 static constexpr auto family_sequence_populate(struct family_sequence<FAMILY...>)
 {
 	return family_sequence<NEW_FAMILY, FAMILY...>{};
 }
 
-template <compact::Family ...FAMILY_A, compact::Family ...FAMILY_B>
+template <Family ...FAMILY_A, Family ...FAMILY_B>
 inline constexpr auto
 operator+(family_sequence<FAMILY_A...>, family_sequence<FAMILY_B...>)
 {
@@ -116,51 +114,51 @@ operator+(family_sequence<FAMILY_A...>, family_sequence<FAMILY_B...>)
 
 namespace details {
 
-template <compact::Family NEEDLE, compact::Family HEAD, compact::Family ...TAIL>
+template <Family NEEDLE, Family HEAD, Family ...TAIL>
 struct family_sequence_contains_impl_h {
 	static constexpr bool value =
 		family_sequence_contains_impl_h<NEEDLE, TAIL...>::value;
 };
 
-template <compact::Family NEEDLE, compact::Family LAST>
+template <Family NEEDLE, Family LAST>
 struct family_sequence_contains_impl_h<NEEDLE, LAST> {
 	static constexpr bool value = false;
 };
 
-template <compact::Family NEEDLE, compact::Family ...TAIL>
+template <Family NEEDLE, Family ...TAIL>
 struct family_sequence_contains_impl_h<NEEDLE, NEEDLE, TAIL...> {
 	static constexpr bool value = true;
 };
 
-template <compact::Family NEEDLE>
+template <Family NEEDLE>
 struct family_sequence_contains_impl_h<NEEDLE, NEEDLE> {
 	static constexpr bool value = true;
 };
 
-template <compact::Family NEEDLE, compact::Family ...HAYSTACK>
+template <Family NEEDLE, Family ...HAYSTACK>
 struct family_sequence_contains_h {
 	static constexpr bool value =
 		family_sequence_contains_impl_h<NEEDLE, HAYSTACK...>::value;
 };
 
-template <compact::Family NEEDLE>
+template <Family NEEDLE>
 struct family_sequence_contains_h<NEEDLE> {
 	static constexpr bool value = false;
 };
 
 } // namespace details
 
-template <compact::Family NEEDLE, compact::Family ...HAYSTACK>
+template <Family NEEDLE, Family ...HAYSTACK>
 static constexpr bool family_sequence_contains(family_sequence<HAYSTACK...>) {
 	return details::family_sequence_contains_h<NEEDLE, HAYSTACK...>::value;
 }
 
-template <compact::Family ...FAMILY>
+template <Family ...FAMILY>
 std::ostream&
 operator<<(std::ostream& strm, family_sequence<FAMILY...>)
 {
 	if (sizeof ...(FAMILY) == 0)
-		return strm << FamilyName[compact::Family::MP_END + 1];
+		return strm << FamilyName[Family::MP_END + 1];
 	size_t count = 0;
 	((strm << (count++ ? ", " : "") << FamilyName[FAMILY]), ...);
 	return strm;

--- a/src/mpp/ContAdapter.hpp
+++ b/src/mpp/ContAdapter.hpp
@@ -1,0 +1,273 @@
+#pragma once
+/*
+ * Copyright 2010-2024 Tarantool AUTHORS: please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY AUTHORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * AUTHORS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <cstdint>
+#include <cstring>
+#include <utility>
+
+#include "../Utils/CStr.hpp"
+#include "../Utils/Traits.hpp"
+
+namespace mpp {
+
+namespace encode_details {
+
+/** Common data+size pair that is used for writing of variable-length data. */
+struct WData {
+	const char *data;
+	size_t size;
+};
+
+/** Random struct; used to check whether container has template write method. */
+struct TestWriteStruct {
+	uint32_t a;
+	uint16_t b;
+};
+
+/** Test that container if Buffer-like: has several needed write methods. */
+template <class CONT, class _ = void>
+struct is_write_callable_h : std::false_type {};
+
+template <class CONT>
+struct is_write_callable_h<CONT,
+	std::void_t<decltype(std::declval<CONT>().write(uint8_t{})),
+		    decltype(std::declval<CONT>().write(uint64_t{})),
+		    decltype(std::declval<CONT>().write(TestWriteStruct{})),
+		    decltype(std::declval<CONT>().write({(const char *)0, 1})),
+		    decltype(std::declval<CONT>().write(tnt::CStr<'a', 'b'>{}))
+		   >> : std::true_type {};
+
+template <class CONT>
+constexpr bool is_write_callable_v = is_write_callable_h<CONT>::value;
+
+template <class CONT>
+class BufferWriter {
+public:
+	explicit BufferWriter(CONT& cont_) : cont{cont_} {}
+	void write(WData data) { cont.write({data.data, data.size}); }
+	template <char... C>
+	void write(tnt::CStr<C...> str)
+	{
+		cont.write(std::move(str));
+	}
+	template <class T>
+	void write(T&& t)
+	{
+		cont.write(std::forward<T>(t));
+	}
+
+private:
+	CONT& cont;
+};
+
+template <class CONT>
+class StdContWriter {
+public:
+	static_assert(sizeof(*std::declval<CONT>().data()) == 1);
+	explicit StdContWriter(CONT& cont_) : cont{cont_} {}
+	void write(WData data)
+	{
+		size_t old_size = std::size(cont);
+		cont.resize(old_size + data.size);
+		std::memcpy(std::data(cont) + old_size, data.data, data.size);
+	}
+	template <char... C>
+	void write(tnt::CStr<C...> data)
+	{
+		size_t old_size = std::size(cont);
+		cont.resize(old_size + data.size);
+		std::memcpy(std::data(cont) + old_size, data.data, data.size);
+	}
+
+	template <class T>
+	void write(T&& t)
+	{
+		static_assert(std::is_standard_layout_v<std::remove_reference_t<T>>);
+		size_t old_size = std::size(cont);
+		cont.resize(old_size + sizeof(T));
+		std::memcpy(std::data(cont) + old_size, &t, sizeof(T));
+	}
+
+private:
+	CONT& cont;
+};
+
+template <class C>
+class PtrWriter {
+public:
+	static_assert(sizeof(C) == 1);
+	static_assert(!std::is_const_v<C>);
+	explicit PtrWriter(C *& ptr_) : ptr{ptr_} {}
+	void write(WData data)
+	{
+		std::memcpy(ptr, data.data, data.size);
+		ptr += data.size;
+	}
+	template <char... D>
+	void write(tnt::CStr<D...> data)
+	{
+		std::memcpy(ptr, data.data, data.size);
+		ptr += data.size;
+	}
+
+	template <class T>
+	void write(T&& t)
+	{
+		static_assert(std::is_standard_layout_v<std::remove_reference_t<T>>);
+		std::memcpy(ptr, &t, sizeof(t));
+		ptr += sizeof(t);
+	}
+
+private:
+	C *& ptr;
+};
+
+template <class CONT>
+auto
+wr(CONT& cont)
+{
+	if constexpr (is_write_callable_v<CONT>)
+		return BufferWriter<CONT>{cont};
+	else if constexpr (tnt::is_resizable_v<CONT> && tnt::is_contiguous_v<CONT>)
+		return StdContWriter<CONT>{cont};
+	else if constexpr (std::is_pointer_v<CONT>)
+		return PtrWriter<std::remove_pointer_t<CONT>>{cont};
+	else
+		static_assert(tnt::always_false_v<CONT>);
+}
+
+} // namespace encode_details
+
+namespace decode_details {
+
+/** Common data+size pair that is used for reading of variable-length data. */
+struct RData {
+	char *data;
+	size_t size;
+};
+
+/** Struct that when used as read argument, means skipping of 'size' data. */
+struct Skip {
+	size_t size;
+};
+
+/** Random struct; used to check whether container has template read method. */
+struct TestReadStruct {
+	uint8_t a;
+	uint64_t b;
+};
+
+/** Test that container if Buffer-like: has several needed read methods. */
+template <class CONT, class _ = void>
+struct is_read_callable_h : std::false_type {};
+
+template <class CONT>
+struct is_read_callable_h<CONT,
+	std::void_t<decltype(std::declval<CONT>().read(*(uint8_t*)0)),
+		    decltype(std::declval<CONT>().read(*(uint64_t*)0)),
+		    decltype(std::declval<CONT>().read(*(TestReadStruct*)0)),
+		    decltype(std::declval<CONT>().read({(char *)0, 1})),
+		    decltype(std::declval<CONT>().template get<uint8_t>()),
+		    decltype(std::declval<CONT>().read({1}))
+		   >> : std::true_type {};
+
+template <class CONT>
+constexpr bool is_read_callable_v = is_read_callable_h<CONT>::value;
+
+template <class CONT>
+class BufferReader {
+public:
+	explicit BufferReader(CONT& cont_) : cont{cont_} {}
+	void read(RData data) { cont.read({data.data, data.size}); }
+	void read(Skip data) { cont.read({data.size}); }
+	template <class T>
+	void read(T&& t)
+	{
+		cont.read(std::forward<T>(t));
+	}
+	template <class T>
+	T get()
+	{
+		return cont.template get<T>();
+	}
+
+private:
+	CONT& cont;
+};
+
+template <class C>
+class PtrReader {
+public:
+	static_assert(sizeof(C) == 1);
+	explicit PtrReader(C *& ptr_) : ptr{ptr_} {}
+	void read(RData data)
+	{
+		std::memcpy(data.data, ptr, data.size);
+		ptr += data.size;
+	}
+	void read(Skip data) { ptr += data.size; }
+
+	template <class T>
+	void read(T& t)
+	{
+		static_assert(std::is_standard_layout_v<std::remove_reference_t<T>>);
+		std::memcpy(&t, ptr, sizeof(t));
+		ptr += sizeof(t);
+	}
+	template <class T>
+	T get()
+	{
+		static_assert(std::is_standard_layout_v<std::remove_reference_t<T>>);
+		T t;
+		std::memcpy(&t, ptr, sizeof(t));
+		return t;
+	}
+
+private:
+	C *& ptr;
+};
+
+template <class CONT>
+auto
+rd(CONT& cont)
+{
+	if constexpr (is_read_callable_v<CONT>)
+		return BufferReader<CONT>{cont};
+	else if constexpr (std::is_pointer_v<CONT>)
+		return PtrReader<std::remove_pointer_t<CONT>>{cont};
+	else
+		static_assert(tnt::always_false_v<CONT>);
+}
+
+} // namespace decode_details
+
+} // namespace mpp

--- a/src/mpp/Dec.hpp
+++ b/src/mpp/Dec.hpp
@@ -131,33 +131,33 @@ constexpr auto detectFamily()
 	} else if constexpr (has_dec_rule_v<U>) {
 		return detectFamily<BUF, decltype(get_dec_rule<U>())>();
 	} else if constexpr (tnt::is_optional_v<U>) {
-		return family_sequence_populate<compact::MP_NIL>(
+		return family_sequence_populate<MP_NIL>(
 			detectFamily<BUF, tnt::value_type_t<U>>());
 	} else if constexpr (tnt::is_variant_v<U>) {
 		return detectFamilyVariant<BUF, U>();
 	} else if constexpr (std::is_convertible_v<U, tnt::empty_type>) {
-		return family_sequence<compact::MP_NIL>{};
+		return family_sequence<MP_NIL>{};
 	} else if constexpr (std::is_same_v<U, bool>) {
-		return family_sequence<compact::MP_BOOL>{};
+		return family_sequence<MP_BOOL>{};
 	} else if constexpr (tnt::is_integer_v<U>) {
-		return family_sequence<compact::MP_INT>{};
+		return family_sequence<MP_INT>{};
 	} else if constexpr (std::is_floating_point_v<U>) {
-		return family_sequence<compact::MP_INT, compact::MP_FLT>{};
+		return family_sequence<MP_INT, MP_FLT>{};
 	} else if constexpr (tnt::is_contiguous_char_v<U>) {
-		return family_sequence<compact::MP_STR>{};
+		return family_sequence<MP_STR>{};
 	} else if constexpr (tnt::is_tuplish_v<U>) {
 		if constexpr (tnt::tuple_size_v<U> == 0)
-			return family_sequence<compact::MP_ARR,
-					       compact::MP_MAP>{};
+			return family_sequence<MP_ARR,
+					       MP_MAP>{};
 		else if constexpr (tnt::is_tuplish_of_pairish_v<U>)
-			return family_sequence<compact::MP_MAP>{};
+			return family_sequence<MP_MAP>{};
 		else
-			return family_sequence<compact::MP_ARR>{};
+			return family_sequence<MP_ARR>{};
 	} else if constexpr (is_any_putable_v<U> || tnt::is_contiguous_v<U>) {
 		if constexpr (tnt::is_pairish_v<tnt::value_type_t<U>>)
-			return family_sequence<compact::MP_MAP>{};
+			return family_sequence<MP_MAP>{};
 		else
-			return family_sequence<compact::MP_ARR>{};
+			return family_sequence<MP_ARR>{};
 	} else {
 		static_assert(tnt::always_false_v<U>,
 			      "Failed to recognise type");
@@ -165,7 +165,7 @@ constexpr auto detectFamily()
 	}
 }
 
-template <compact::Family... FAMILY>
+template <Family... FAMILY>
 constexpr bool hasChildren(family_sequence<FAMILY...>)
 {
 	return (rule_by_family_t<FAMILY>::has_children || ...);
@@ -393,7 +393,7 @@ constexpr auto&& path_resolve_parent(tnt::iseq<P...>, T... t)
 
 constexpr size_t SIMPLEX_SUBRULE = 16;
 
-template <compact::Family FAMILY>
+template <Family FAMILY>
 constexpr auto get_subrules()
 {
 	using RULE = rule_by_family_t<FAMILY>;
@@ -405,7 +405,7 @@ constexpr auto get_subrules()
 		return complex_seq{};
 }
 
-template <compact::Family FAMILY, size_t SUBRULE, class BUF>
+template <Family FAMILY, size_t SUBRULE, class BUF>
 auto read_value(BUF& buf)
 {
 	using RULE = rule_by_family_t<FAMILY>;
@@ -417,7 +417,7 @@ auto read_value(BUF& buf)
 		[[maybe_unused]] typename RULE::simplex_value_t val =
 			tag - RULE::simplex_tag;
 
-		if constexpr (FAMILY == compact::MP_NIL)
+		if constexpr (FAMILY == MP_NIL)
 			return tnt::empty_value;
 		else if constexpr (RULE::is_bool)
 			return bool(val);
@@ -438,7 +438,7 @@ auto read_value(BUF& buf)
 	}
 }
 
-template <compact::Family FAMILY, size_t SUBRULE, class BUF, class ITEM>
+template <Family FAMILY, size_t SUBRULE, class BUF, class ITEM>
 auto read_item(BUF& buf, ITEM& item)
 {
 	using RULE = rule_by_family_t<FAMILY>;
@@ -481,7 +481,7 @@ auto read_item(BUF& buf, ITEM& item)
 			item.resize(val);
 	} else if constexpr (std::is_enum_v<ITEM>) {
 		item = static_cast<ITEM>(val);
-	} else if constexpr (tnt::is_optional_v<ITEM> && FAMILY == compact::MP_NIL) {
+	} else if constexpr (tnt::is_optional_v<ITEM> && FAMILY == MP_NIL) {
 		item.reset();
 	} else {
 		item = val;
@@ -580,7 +580,7 @@ struct Jumps {
 	}
 };
 
-template <compact::Family FAMILY, size_t SUBRULE,
+template <Family FAMILY, size_t SUBRULE,
 	class PATH, class BUF, class... T>
 bool jump_common(BUF& buf, T... t);
 
@@ -592,7 +592,7 @@ bool broken_msgpack_jump(BUF&, T...);
 
 template <class PATH, class BUF, class... T>
 struct JumpsBuilder {
-	template <compact::Family FAMILY, size_t SUBRULE>
+	template <Family FAMILY, size_t SUBRULE>
 	static constexpr auto build()
 	{
 		using RULE = rule_by_family_t<FAMILY>;
@@ -609,13 +609,13 @@ struct JumpsBuilder {
 		}
 	}
 
-	template <compact::Family FAMILY, size_t... SUBRULE>
+	template <Family FAMILY, size_t... SUBRULE>
 	static constexpr auto build(tnt::iseq<SUBRULE...>)
 	{
 		return (build<FAMILY, SUBRULE>() + ...);
 	}
 
-	template <compact::Family... FAMILY>
+	template <Family... FAMILY>
 	static constexpr auto build(family_sequence<FAMILY...> s)
 	{
 		if constexpr (s.size() == 0)
@@ -665,11 +665,11 @@ struct JumpsBuilder {
 		constexpr bool has_str =
 			(is_str_key<tnt::tuple_element_t<I, TYPES>>() || ...);
 		if constexpr (has_int && has_str)
-			return family_sequence<compact::MP_INT, compact::MP_STR>{};
+			return family_sequence<MP_INT, MP_STR>{};
 		else if constexpr (has_int)
-			return family_sequence<compact::MP_INT>{};
+			return family_sequence<MP_INT>{};
 		else if constexpr (has_str)
-			return family_sequence<compact::MP_STR>{};
+			return family_sequence<MP_STR>{};
 		else
 			return family_sequence<>{};
 	}
@@ -912,7 +912,7 @@ bool decode_next(BUF& buf, T... t)
 	}
 }
 
-template <compact::Family FAMILY, size_t SUBRULE,
+template <Family FAMILY, size_t SUBRULE,
 	class PATH, class BUF, class... T>
 bool jump_skip(BUF& buf, T... t)
 {
@@ -934,7 +934,7 @@ bool jump_skip(BUF& buf, T... t)
 	return decode_next<PATH>(buf, t...);
 }
 
-template <compact::Family FAMILY, size_t SUBRULE,
+template <Family FAMILY, size_t SUBRULE,
 	class PATH, class BUF, class... T>
 bool jump_add(BUF& buf, T... t)
 {
@@ -981,7 +981,7 @@ constexpr size_t get_next_arr_static_size()
 		return 0;
 }
 
-template <compact::Family FAMILY, size_t SUBRULE,
+template <Family FAMILY, size_t SUBRULE,
 	  class PATH, class BUF, class... T>
 bool jump_read(BUF& buf, T... t)
 {
@@ -994,7 +994,7 @@ bool jump_read(BUF& buf, T... t)
 			return decode_next<PATH>(buf, t...);
 	}
 
-	if constexpr (FAMILY == compact::MP_ARR) {
+	if constexpr (FAMILY == MP_ARR) {
 		constexpr auto NT = get_next_arr_item_type<BUF, dst_t>();
 		constexpr size_t NS = get_next_arr_static_size<dst_t, NT>();
 		using NEXT_PATH = path_push_t<PATH, NT, NS>;
@@ -1028,7 +1028,7 @@ bool jump_read(BUF& buf, T... t)
 			uint64_t arg = val;
 			return decode_impl<NEXT_PATH>(buf, t..., arg);
 		}
-	} else if constexpr (FAMILY == compact::MP_MAP) {
+	} else if constexpr (FAMILY == MP_MAP) {
 		if constexpr (tnt::is_tuplish_v<dst_t>) {
 			uint64_t arg = val;
 			using NEXT_PATH = path_push_t<PATH, PIT_DYN_KEY>;
@@ -1072,14 +1072,14 @@ constexpr bool signed_compare(K k, V v)
 	}
 }
 
-template <compact::Family FAMILY, class K, class W, class BUF>
+template <Family FAMILY, class K, class W, class BUF>
 constexpr bool compare_key([[maybe_unused]] K k, W&& w, [[maybe_unused]] BUF& buf)
 {
 	auto&& u = mpp::unwrap(w);
 	using U = mpp::unwrap_t<W>;
 	static_assert(std::is_integral_v<K>);
 	static_assert(!std::is_same_v<K, bool>);
-	if constexpr (FAMILY == compact::MP_INT) {
+	if constexpr (FAMILY == MP_INT) {
 		if constexpr (tnt::is_integral_constant_v<U>) {
 			using V = typename U::value_type;
 			constexpr tnt::base_enum_t<V> v = U::value;
@@ -1091,7 +1091,7 @@ constexpr bool compare_key([[maybe_unused]] K k, W&& w, [[maybe_unused]] BUF& bu
 			return false;
 		}
 	} else {
-		static_assert(FAMILY == compact::MP_STR);
+		static_assert(FAMILY == MP_STR);
 		if constexpr (tnt::is_string_constant_v<U>) {
 			return k == u.size && buf.startsWith({u.data, u.size});
 		} else if constexpr (tnt::is_char_ptr_v<U>) {
@@ -1109,13 +1109,13 @@ constexpr bool compare_key([[maybe_unused]] K k, W&& w, [[maybe_unused]] BUF& bu
 	}
 }
 
-template <bool PAIRS, compact::Family FAMILY, class PATH, class K,
+template <bool PAIRS, Family FAMILY, class PATH, class K,
           class BUF, class... T>
 bool jump_find_key([[maybe_unused]] K k, tnt::iseq<>, BUF& buf, T... t)
 {
 	static_assert(path_item_type(PATH::last()) == PIT_DYN_KEY);
 	using NEXT_PATH = path_push_t<PATH, PIT_DYN_SKIP>;
-	if constexpr (FAMILY == compact::MP_STR)
+	if constexpr (FAMILY == MP_STR)
 		buf.read({k});
 	return decode_impl<NEXT_PATH>(buf, t..., size_t(1));
 }
@@ -1129,7 +1129,7 @@ auto&& key_path_resolve(DST&& dst)
 		return tnt::get<I * 2>(dst);
 }
 
-template <bool PAIRS, compact::Family FAMILY, class PATH, class K,
+template <bool PAIRS, Family FAMILY, class PATH, class K,
 	  size_t I, size_t... J, class BUF, class... T>
 bool jump_find_key(K k, tnt::iseq<I, J...>, BUF& buf, T... t)
 {
@@ -1142,7 +1142,7 @@ bool jump_find_key(K k, tnt::iseq<I, J...>, BUF& buf, T... t)
 	using NEXT_PATH = std::conditional_t<PAIRS, PAIRS_NEXT_PATH, FLAT_NEXT_PATH>;
 
 	if (compare_key<FAMILY>(k, key, buf)) {
-		if constexpr (FAMILY == compact::MP_STR)
+		if constexpr (FAMILY == MP_STR)
 			buf.read({k});
 		return decode_impl<NEXT_PATH>(buf, t...);
 	}
@@ -1151,7 +1151,7 @@ bool jump_find_key(K k, tnt::iseq<I, J...>, BUF& buf, T... t)
 	return jump_find_key<PAIRS, FAMILY, PATH>(k, IS, buf, t...);
 }
 
-template <compact::Family FAMILY, size_t SUBRULE,
+template <Family FAMILY, size_t SUBRULE,
 	  class PATH, class BUF, class... T>
 bool jump_read_key(BUF& buf, T... t)
 {
@@ -1166,24 +1166,24 @@ bool jump_read_key(BUF& buf, T... t)
 	constexpr size_t S = PAIRS ? TS : TS / 2;
 	constexpr auto IS = tnt::make_iseq<S>{};
 
-	static_assert(FAMILY == compact::MP_INT || FAMILY == compact::MP_STR);
+	static_assert(FAMILY == MP_INT || FAMILY == MP_STR);
 	auto val = read_value<FAMILY, SUBRULE>(buf);
 
 	return jump_find_key<PAIRS, FAMILY, PATH>(val, IS, buf, t...);
 }
 
-template <compact::Family FAMILY, size_t SUBRULE, class DST, class BUF>
+template <Family FAMILY, size_t SUBRULE, class DST, class BUF>
 constexpr bool is_object_readable_by_value_v = rule_by_family_t<FAMILY>::is_readable_by_value
 	&& std::is_assignable_v<DST, decltype(read_value<FAMILY, SUBRULE>(std::declval<BUF &>()))>;
 
-template <compact::Family FAMILY, size_t SUBRULE,
+template <Family FAMILY, size_t SUBRULE,
 	  class PATH, class BUF, class... T>
 bool jump_read_optional(BUF& buf, T... t)
 {
 	auto&& dst = unwrap(path_resolve(PATH{}, t...));
 	using dst_t = std::remove_reference_t<decltype(dst)>;
 	static_assert(tnt::is_optional_v<dst_t>);
-	if constexpr (FAMILY == compact::MP_NIL) {
+	if constexpr (FAMILY == MP_NIL) {
 		[[maybe_unused]] auto val = read_value<FAMILY, SUBRULE>(buf);
 		dst.reset();
 		return decode_next<PATH>(buf, t...);
@@ -1200,7 +1200,7 @@ bool jump_read_optional(BUF& buf, T... t)
 	}
 }
 
-template <size_t I, compact::Family FAMILY, size_t SUBRULE,
+template <size_t I, Family FAMILY, size_t SUBRULE,
 	  class PATH, class BUF, class... T>
 bool jump_read_variant_impl(BUF& buf, T... t)
 {
@@ -1221,7 +1221,7 @@ bool jump_read_variant_impl(BUF& buf, T... t)
 	}
 }
 
-template <compact::Family FAMILY, size_t SUBRULE,
+template <Family FAMILY, size_t SUBRULE,
 	  class PATH, class BUF, class... T>
 bool jump_read_variant(BUF& buf, T... t)
 {
@@ -1236,7 +1236,7 @@ bool jump_read_variant(BUF& buf, T... t)
 	}
 }
 
-template <compact::Family FAMILY, size_t SUBRULE,
+template <Family FAMILY, size_t SUBRULE,
 	  class PATH, class BUF, class... T>
 bool jump_common(BUF& buf, T... t)
 {

--- a/src/mpp/Enc.hpp
+++ b/src/mpp/Enc.hpp
@@ -68,7 +68,7 @@ namespace encode_details {
 struct Nothing {};
 
 template <class T>
-constexpr compact::Family detectFamily()
+constexpr Family detectFamily()
 {
 	using fixed_t = get_fixed_t<T>;
 	constexpr bool is_non_void_fixed = !std::is_same_v<fixed_t, void>;
@@ -77,33 +77,33 @@ constexpr compact::Family detectFamily()
 	if constexpr (is_wrapped_family_v<T>) {
 		return T::family;
 	} else if constexpr (std::is_convertible_v<V, tnt::empty_type>) {
-		return compact::MP_NIL;
+		return MP_NIL;
 	} else if constexpr (std::is_same_v<V, bool>) {
-		return compact::MP_BOOL;
+		return MP_BOOL;
 	} else if constexpr (tnt::is_integer_v<V>) {
-		return compact::MP_INT;
+		return MP_INT;
 	} else if constexpr (std::is_floating_point_v<V>) {
-		return compact::MP_FLT;
+		return MP_FLT;
 	} else if constexpr (tnt::is_string_constant_v<V>) {
-		return compact::MP_STR;
+		return MP_STR;
 	} else if constexpr (tnt::is_char_ptr_v<V>) {
-		return compact::MP_STR;
+		return MP_STR;
 	} else if constexpr (tnt::is_contiguous_char_v<V>) {
-		return compact::MP_STR;
+		return MP_STR;
 	} else if constexpr (tnt::is_const_pairs_iterable_v<V>) {
-		return compact::MP_MAP;
+		return MP_MAP;
 	} else if constexpr (tnt::is_const_iterable_v<V>) {
-		return compact::MP_ARR;
+		return MP_ARR;
 	} else if constexpr (tnt::is_tuplish_of_pairish_v<V>) {
 		if constexpr(tnt::tuple_size_v<V> == 0)
-			return compact::MP_ARR;
+			return MP_ARR;
 		else
-			return compact::MP_MAP;
+			return MP_MAP;
 	} else if constexpr (tnt::is_tuplish_v<V>) {
-		return compact::MP_ARR;
+		return MP_ARR;
 	} else {
 		static_assert(tnt::always_false_v<V>, "Failed to recognise type");
-		return compact::MP_END;
+		return MP_END;
 	}
 }
 
@@ -146,10 +146,10 @@ auto uniSize32([[maybe_unused]]const U& u)
 	}
 }
 
-template<compact::Family FAMILY, class T, class U>
+template<Family FAMILY, class T, class U>
 auto getValue([[maybe_unused]] const T& t, [[maybe_unused]] const U& u)
 {
-	if constexpr (FAMILY == compact::MP_STR) {
+	if constexpr (FAMILY == MP_STR) {
 		static_assert(tnt::is_char_ptr_v<U> ||
 			      tnt::is_string_constant_v<U> ||
 			      tnt::is_contiguous_char_v<U>);
@@ -162,8 +162,8 @@ auto getValue([[maybe_unused]] const T& t, [[maybe_unused]] const U& u)
 				      tnt::is_contiguous_char_v<U>);
 			return uniLength32(u);
 		}
-	} else if constexpr (FAMILY == compact::MP_BIN ||
-			     FAMILY == compact::MP_EXT) {
+	} else if constexpr (FAMILY == MP_BIN ||
+			     FAMILY == MP_EXT) {
 		if constexpr(tnt::is_string_constant_v<U> ||
 			     tnt::is_contiguous_v<U>) {
 			return uniLength32(u);
@@ -171,9 +171,9 @@ auto getValue([[maybe_unused]] const T& t, [[maybe_unused]] const U& u)
 			static_assert(std::is_standard_layout_v<U>);
 			return std::integral_constant<uint32_t, sizeof(U)>{};
 		}
-	} else if constexpr (FAMILY == compact::MP_ARR) {
+	} else if constexpr (FAMILY == MP_ARR) {
 		return uniSize32(u);
-	} else if constexpr (FAMILY == compact::MP_MAP) {
+	} else if constexpr (FAMILY == MP_MAP) {
 		if constexpr(tnt::is_tuplish_of_pairish_v<U> ||
 			     tnt::is_const_pairs_iterable_v<U>) {
 			return uniSize32(u);
@@ -191,10 +191,10 @@ auto getValue([[maybe_unused]] const T& t, [[maybe_unused]] const U& u)
 	}
 }
 
-template <compact::Family FAMILY, class T, class U>
+template <Family FAMILY, class T, class U>
 auto getExtType([[maybe_unused]] const T& t, [[maybe_unused]] const U& u)
 {
-	if constexpr (FAMILY == compact::MP_EXT) {
+	if constexpr (FAMILY == MP_EXT) {
 		using E = std::remove_cv_t<decltype(t.ext_type)>;
 		if constexpr(tnt::is_integral_constant_v<E>) {
 			using V = std::remove_cv_t<decltype(t.ext_type.value)>;
@@ -234,11 +234,11 @@ template <class V> struct ChildrenPairs : ChildrenPairsTag {
 	explicit ChildrenPairs(const V& u) : v(u) {}
 };
 
-template<compact::Family FAMILY, class T, class U, class V>
+template<Family FAMILY, class T, class U, class V>
 auto getData([[maybe_unused]] const T& t, [[maybe_unused]] const U& u,
 	     [[maybe_unused]] const V& value)
 {
-	if constexpr (FAMILY == compact::MP_STR) {
+	if constexpr (FAMILY == MP_STR) {
 		if constexpr (tnt::is_char_ptr_v<U> ||
 			      tnt::is_bounded_array_v<U>) {
 			using check0_t = decltype(u[0]);
@@ -258,8 +258,8 @@ auto getData([[maybe_unused]] const T& t, [[maybe_unused]] const U& u,
 			return std::string_view{std::data(u), std::size(u)};
 		}
 
-	} else if constexpr (FAMILY == compact::MP_BIN ||
-			     FAMILY == compact::MP_EXT) {
+	} else if constexpr (FAMILY == MP_BIN ||
+			     FAMILY == MP_EXT) {
 		if constexpr(tnt::is_string_constant_v<U>) {
 			return u;
 		} else if constexpr(tnt::is_contiguous_v<U>) {
@@ -270,9 +270,9 @@ auto getData([[maybe_unused]] const T& t, [[maybe_unused]] const U& u,
 			auto p = reinterpret_cast<const char*>(&u);
 			return std::string_view{p, value};
 		}
-	} else if constexpr (FAMILY == compact::MP_ARR) {
+	} else if constexpr (FAMILY == MP_ARR) {
 		return Children<U>{u};
-	} else if constexpr (FAMILY == compact::MP_MAP) {
+	} else if constexpr (FAMILY == MP_MAP) {
 		if constexpr(tnt::is_tuplish_of_pairish_v<U> ||
 			     tnt::is_const_pairs_iterable_v<U>)
 			return ChildrenPairs<U>{u};
@@ -283,10 +283,10 @@ auto getData([[maybe_unused]] const T& t, [[maybe_unused]] const U& u,
 	}
 }
 
-template<compact::Family FAMILY, class T, class U>
+template<Family FAMILY, class T, class U>
 auto getIS([[maybe_unused]] const T& t, [[maybe_unused]] const U& u)
 {
-	if constexpr (FAMILY == compact::MP_ARR || FAMILY == compact::MP_MAP) {
+	if constexpr (FAMILY == MP_ARR || FAMILY == MP_MAP) {
 		if constexpr(tnt::is_tuplish_v<U>) {
 			return tnt::tuple_iseq<U>{};
 		} else {
@@ -357,8 +357,8 @@ constexpr bool can_encode_simple()
 template <class RULE, bool IS_FIXED, class FIXED_T, class V>
 constexpr auto getTagValSimple([[maybe_unused]] V value)
 {
-	if constexpr(RULE::family == compact::MP_NIL ||
-		     RULE::family == compact::MP_IGNR) {
+	if constexpr(RULE::family == MP_NIL ||
+		     RULE::family == MP_IGNR) {
 		// That type is completely independent on value
 		static_assert(!IS_FIXED || std::is_same_v<FIXED_T, void>);
 		constexpr char t = static_cast<char>(RULE::simplex_tag);
@@ -654,7 +654,7 @@ encode(CONT &cont, tnt::CStr<C...> prefix,
 	} else {
 		constexpr bool is_fixed = is_wrapped_fixed_v<T>;
 		using fixed_t = get_fixed_t<T>;
-		constexpr compact::Family family = detectFamily<T>();
+		constexpr Family family = detectFamily<T>();
 		using rule_t = rule_by_family_t<family>;
 		auto value = getValue<family>(t, u);
 		using V = decltype(value);

--- a/src/mpp/Rules.hpp
+++ b/src/mpp/Rules.hpp
@@ -108,55 +108,55 @@ struct RuleRange {
 						 count(last - first + 1) {}
 };
 
-template <compact::Family FAMILY, class ...TYPE>
+template <Family FAMILY, class ...TYPE>
 struct BaseRule {
 	// Widest types that can represent the value.
 	using types = std::tuple<TYPE...>;
 	// Msgpack family.
-	static constexpr compact::Family family = FAMILY;
+	static constexpr Family family = FAMILY;
 	// The rule stores bool values.
-	static constexpr bool is_bool = FAMILY == compact::MP_BOOL;
+	static constexpr bool is_bool = FAMILY == MP_BOOL;
 	// The rule stores floating point values.
-	static constexpr bool is_floating_point = FAMILY == compact::MP_FLT;
+	static constexpr bool is_floating_point = FAMILY == MP_FLT;
 	// The rule actually doest not store value, only type matters.
-	static constexpr bool is_valueless = FAMILY == compact::MP_NIL ||
-					     FAMILY == compact::MP_IGNR;
+	static constexpr bool is_valueless = FAMILY == MP_NIL ||
+					     FAMILY == MP_IGNR;
 	// The encoded object has data section (of size equal to value).
-	static constexpr bool has_data = FAMILY == compact::MP_STR ||
-					 FAMILY == compact::MP_BIN ||
-					 FAMILY == compact::MP_EXT;
+	static constexpr bool has_data = FAMILY == MP_STR ||
+					 FAMILY == MP_BIN ||
+					 FAMILY == MP_EXT;
 	// The encoded object has ext type byte.
-	static constexpr bool has_ext = FAMILY == compact::MP_EXT;
+	static constexpr bool has_ext = FAMILY == MP_EXT;
 	// The encoded object has children...
-	static constexpr bool has_children = FAMILY == compact::MP_ARR ||
-					     FAMILY == compact::MP_MAP;
+	static constexpr bool has_children = FAMILY == MP_ARR ||
+					     FAMILY == MP_MAP;
 	// ... and the number of children is value * children_multiplier.
 	static constexpr uint32_t children_multiplier =
-		FAMILY == compact::MP_ARR ? 1 :
-		FAMILY == compact::MP_MAP ? 2 : 0;
+		FAMILY == MP_ARR ? 1 :
+		FAMILY == MP_MAP ? 2 : 0;
 	// The encoded object can be read by value.
 	static constexpr bool is_readable_by_value = !has_data && !has_ext && !has_children;
 	// The rule has simplex form.
-	static constexpr bool has_simplex = FAMILY == compact::MP_NIL ||
-					    FAMILY == compact::MP_IGNR ||
-					    FAMILY == compact::MP_BOOL ||
-					    FAMILY == compact::MP_INT ||
-					    FAMILY == compact::MP_STR ||
-					    FAMILY == compact::MP_ARR ||
-					    FAMILY == compact::MP_MAP ||
-					    FAMILY == compact::MP_EXT;
+	static constexpr bool has_simplex = FAMILY == MP_NIL ||
+					    FAMILY == MP_IGNR ||
+					    FAMILY == MP_BOOL ||
+					    FAMILY == MP_INT ||
+					    FAMILY == MP_STR ||
+					    FAMILY == MP_ARR ||
+					    FAMILY == MP_MAP ||
+					    FAMILY == MP_EXT;
 	// The rule has simplex form.
-	static constexpr bool has_complex = FAMILY == compact::MP_INT ||
-					    FAMILY == compact::MP_FLT ||
-					    FAMILY == compact::MP_STR ||
-					    FAMILY == compact::MP_BIN ||
-					    FAMILY == compact::MP_ARR ||
-					    FAMILY == compact::MP_MAP ||
-					    FAMILY == compact::MP_EXT;
+	static constexpr bool has_complex = FAMILY == MP_INT ||
+					    FAMILY == MP_FLT ||
+					    FAMILY == MP_STR ||
+					    FAMILY == MP_BIN ||
+					    FAMILY == MP_ARR ||
+					    FAMILY == MP_MAP ||
+					    FAMILY == MP_EXT;
 	// The rule has signed simplex range.
-	static constexpr bool is_simplex_signed = FAMILY == compact::MP_INT;
+	static constexpr bool is_simplex_signed = FAMILY == MP_INT;
 	// The rule has logarithmic simplex range.
-	static constexpr bool is_simplex_log_range = FAMILY == compact::MP_EXT;
+	static constexpr bool is_simplex_log_range = FAMILY == MP_EXT;
 	// The type of simplex value in simplex range.
 	using simplex_value_t =
 		std::conditional_t<is_simplex_signed, int8_t, uint8_t>;
@@ -164,22 +164,22 @@ struct BaseRule {
 	using simplex_value_range_t = RuleRange<simplex_value_t>;
 };
 
-struct NilRule : BaseRule<compact::MP_NIL, std::nullptr_t, std::monostate, std::nullopt_t> {
+struct NilRule : BaseRule<MP_NIL, std::nullptr_t, std::monostate, std::nullopt_t> {
 	static constexpr simplex_value_range_t simplex_value_range = {0, 0};
 	static constexpr uint8_t simplex_tag = 0xc0;
 };
 
-struct IgnrRule : BaseRule<compact::MP_IGNR, decltype(std::ignore)> {
+struct IgnrRule : BaseRule<MP_IGNR, decltype(std::ignore)> {
 	static constexpr simplex_value_range_t simplex_value_range = {0, 0};
 	static constexpr uint8_t simplex_tag = 0xc1;
 };
 
-struct BoolRule : BaseRule<compact::MP_BOOL, bool> {
+struct BoolRule : BaseRule<MP_BOOL, bool> {
 	static constexpr simplex_value_range_t simplex_value_range = {0, 1};
 	static constexpr uint8_t simplex_tag = 0xc2;
 };
 
-struct IntRule : BaseRule<compact::MP_INT, uint64_t, int64_t> {
+struct IntRule : BaseRule<MP_INT, uint64_t, int64_t> {
 	static constexpr simplex_value_range_t simplex_value_range = {-32, 127};
 	static constexpr uint8_t simplex_tag = 0x00;
 	using complex_types = std::tuple<uint8_t, uint16_t, uint32_t, uint64_t,
@@ -187,38 +187,38 @@ struct IntRule : BaseRule<compact::MP_INT, uint64_t, int64_t> {
 	static constexpr uint8_t complex_tag = 0xcc;
 };
 
-struct FltRule : BaseRule<compact::MP_FLT, double> {
+struct FltRule : BaseRule<MP_FLT, double> {
 	using complex_types = std::tuple<float, double>;
 	static constexpr uint8_t complex_tag = 0xca;
 };
 
-struct StrRule : BaseRule<compact::MP_STR, uint32_t> {
+struct StrRule : BaseRule<MP_STR, uint32_t> {
 	static constexpr simplex_value_range_t simplex_value_range = {0, 31};
 	static constexpr uint8_t simplex_tag = 0xa0;
 	using complex_types = std::tuple<uint8_t, uint16_t, uint32_t>;
 	static constexpr uint8_t complex_tag = 0xd9;
 };
 
-struct BinRule : BaseRule<compact::MP_BIN, uint32_t> {
+struct BinRule : BaseRule<MP_BIN, uint32_t> {
 	using complex_types = std::tuple<uint8_t, uint16_t, uint32_t>;
 	static constexpr uint8_t complex_tag = 0xc4;
 };
 
-struct ArrRule : BaseRule<compact::MP_ARR, uint32_t> {
+struct ArrRule : BaseRule<MP_ARR, uint32_t> {
 	static constexpr simplex_value_range_t simplex_value_range = {0, 15};
 	static constexpr uint8_t simplex_tag = 0x90;
 	using complex_types = std::tuple<uint16_t, uint32_t>;
 	static constexpr uint8_t complex_tag = 0xdc;
 };
 
-struct MapRule : BaseRule<compact::MP_MAP, uint32_t> {
+struct MapRule : BaseRule<MP_MAP, uint32_t> {
 	static constexpr simplex_value_range_t simplex_value_range = {0, 15};
 	static constexpr uint8_t simplex_tag = 0x80;
 	using complex_types = std::tuple<uint16_t, uint32_t>;
 	static constexpr uint8_t complex_tag = 0xde;
 };
 
-struct ExtRule : BaseRule<compact::MP_EXT, uint32_t> {
+struct ExtRule : BaseRule<MP_EXT, uint32_t> {
 	static constexpr simplex_value_range_t simplex_value_range = {0, 4};
 	static constexpr uint8_t simplex_tag = 0xd4;
 	using complex_types = std::tuple<uint8_t, uint16_t, uint32_t>;
@@ -229,9 +229,9 @@ using all_rules_t = std::tuple<NilRule, IgnrRule, BoolRule, IntRule,
 	FltRule, StrRule, BinRule, ArrRule, MapRule, ExtRule>;
 
 /**
- * Find a rule by compact::Family.
+ * Find a rule by Family.
  */
-template <compact::Family FAMILY>
+template <Family FAMILY>
 using rule_by_family_t = std::tuple_element_t<FAMILY, all_rules_t>;
 
 /**
@@ -397,7 +397,7 @@ constexpr size_t rule_complex_apply(E eval, F &&f)
 	static_assert(RULE::has_complex);
 	auto val = details::rule_unenum(eval);
 	using V = decltype(val);
-	constexpr bool is_int = RULE::family == compact::MP_INT;
+	constexpr bool is_int = RULE::family == MP_INT;
 	constexpr size_t N = rule_complex_count_v<RULE>;
 	if constexpr (is_int && std::is_signed_v<V>) {
 		static_assert(N == 8);

--- a/src/mpp/Spec.hpp
+++ b/src/mpp/Spec.hpp
@@ -45,18 +45,18 @@ namespace mpp {
  * use temporary specificators, like encoder.add(mpp::as_map(<that tuple>)).
  */
 
-template <compact::Family FAMILY, class T>
+template <Family FAMILY, class T>
 constexpr auto as_family(T&& t);
 
-template <class T> constexpr auto as_nil (T&& t) { return as_family<compact::MP_NIL >(std::forward<T>(t)); }
-template <class T> constexpr auto as_ignr(T&& t) { return as_family<compact::MP_IGNR>(std::forward<T>(t)); }
-template <class T> constexpr auto as_bool(T&& t) { return as_family<compact::MP_BOOL>(std::forward<T>(t)); }
-template <class T> constexpr auto as_int (T&& t) { return as_family<compact::MP_INT >(std::forward<T>(t)); }
-template <class T> constexpr auto as_flt (T&& t) { return as_family<compact::MP_FLT >(std::forward<T>(t)); }
-template <class T> constexpr auto as_str (T&& t) { return as_family<compact::MP_STR >(std::forward<T>(t)); }
-template <class T> constexpr auto as_bin (T&& t) { return as_family<compact::MP_BIN >(std::forward<T>(t)); }
-template <class T> constexpr auto as_arr (T&& t) { return as_family<compact::MP_ARR >(std::forward<T>(t)); }
-template <class T> constexpr auto as_map (T&& t) { return as_family<compact::MP_MAP >(std::forward<T>(t)); }
+template <class T> constexpr auto as_nil (T&& t) { return as_family<MP_NIL >(std::forward<T>(t)); }
+template <class T> constexpr auto as_ignr(T&& t) { return as_family<MP_IGNR>(std::forward<T>(t)); }
+template <class T> constexpr auto as_bool(T&& t) { return as_family<MP_BOOL>(std::forward<T>(t)); }
+template <class T> constexpr auto as_int (T&& t) { return as_family<MP_INT >(std::forward<T>(t)); }
+template <class T> constexpr auto as_flt (T&& t) { return as_family<MP_FLT >(std::forward<T>(t)); }
+template <class T> constexpr auto as_str (T&& t) { return as_family<MP_STR >(std::forward<T>(t)); }
+template <class T> constexpr auto as_bin (T&& t) { return as_family<MP_BIN >(std::forward<T>(t)); }
+template <class T> constexpr auto as_arr (T&& t) { return as_family<MP_ARR >(std::forward<T>(t)); }
+template <class T> constexpr auto as_map (T&& t) { return as_family<MP_MAP >(std::forward<T>(t)); }
 
 template <class EXT_TYPE, class T>
 constexpr auto as_ext(EXT_TYPE&& e, T&& t);
@@ -97,20 +97,20 @@ struct wrapped : wrapped_tag
 	constexpr explicit wrapped(T&& arg) : object(std::forward<T>(arg)) {}
 };
 
-template <compact::Family FAMILY, class BASE>
+template <Family FAMILY, class BASE>
 struct wrapped_family : wrapped_family_tag, BASE {
-	static constexpr compact::Family family = FAMILY;
+	static constexpr Family family = FAMILY;
 	constexpr explicit wrapped_family(BASE&& arg)
 	: BASE(std::forward<BASE>(arg)) {}
 };
 
-template <compact::Family FAMILY, class T>
+template <Family FAMILY, class T>
 constexpr auto as_family(T&& t)
 {
 	static_assert(!is_wrapped_family_v<T>, "Family is already set");
 	static_assert(!is_wrapped_raw_v<T>, "Incompatible with raw");
-	static_assert(FAMILY < compact::MP_END, "Invalid family");
-	static_assert(FAMILY != compact::MP_EXT, "Please use as_ext");
+	static_assert(FAMILY < MP_END, "Invalid family");
+	static_assert(FAMILY != MP_EXT, "Please use as_ext");
 
 	if constexpr(is_wrapped_v<T>) {
 		using WRAP_T = std::remove_reference_t<T>;
@@ -123,7 +123,7 @@ constexpr auto as_family(T&& t)
 
 template <class EXT_TYPE, class BASE>
 struct wrapped_ext : wrapped_family_tag, BASE {
-	static constexpr compact::Family family = compact::MP_EXT;
+	static constexpr Family family = MP_EXT;
 	EXT_TYPE ext_type;
 	constexpr wrapped_ext(EXT_TYPE e, BASE&& arg)
 	: BASE(std::forward<BASE>(arg)), ext_type(e) {}

--- a/test/EncDecGPerfTest.cpp
+++ b/test/EncDecGPerfTest.cpp
@@ -103,6 +103,10 @@ struct SimpleRData {
 	size_t size;
 };
 
+struct SimpleSkip {
+	size_t size;
+};
+
 struct SimpleReader {
 	const char *pos;
 
@@ -111,19 +115,15 @@ struct SimpleReader {
 		memcpy(data.data, pos, data.size);
 		pos += data.size;
 	}
+	void read(SimpleSkip data)
+	{
+		pos += data.size;
+	}
 	template <class T>
 	void read(T &t)
 	{
 		memcpy(&t, pos, sizeof(t));
 		pos += sizeof(t);
-	}
-	template <class T>
-	T read()
-	{
-		T t;
-		memcpy(&t, pos, sizeof(t));
-		pos += sizeof(t);
-		return t;
 	}
 	template <class T>
 	T get()

--- a/test/EncDecTest.cpp
+++ b/test/EncDecTest.cpp
@@ -230,6 +230,7 @@ test_basic()
 	mpp::encode(buf, std::integral_constant<bool, false>{});
 	mpp::encode(buf, std::integral_constant<bool, true>{});
 	// Strings.
+	mpp::encode(buf, "");
 	mpp::encode(buf, "abc");
 	const char *bbb = "defg";
 	mpp::encode(buf, bbb);
@@ -322,7 +323,9 @@ test_basic()
 	fail_if(bt != true);
 
 	// Strings.
-	std::string a;
+	std::string a = "nothing";
+	fail_unless(mpp::decode(run, a));
+	fail_if(a != "");
 	char b_data[10];
 	size_t b_size = 0;
 	auto b = tnt::make_ref_vector(b_data, b_size);

--- a/test/EncDecTest.cpp
+++ b/test/EncDecTest.cpp
@@ -167,11 +167,6 @@ test_type_visual()
 	std::cout << compact::MP_ARR << " "
 		  << compact::MP_MAP << " "
 		  << compact::MP_EXT << "\n";
-	std::cout << MP_NIL << " "
-		  << MP_BOOL << " "
-		  << (MP_INT) << " "
-		  << (MP_BIN | MP_STR) << " "
-		  << (MP_INT | MP_FLT) << "\n";
 
 	std::cout << "(" << family_sequence<>{} << ") "
 		  << "(" << family_sequence<compact::MP_NIL>{} << ") "

--- a/test/EncDecTest.cpp
+++ b/test/EncDecTest.cpp
@@ -1323,6 +1323,39 @@ test_variant()
 	fail_unless(monostate_wr == monostate_rd);
 }
 
+void
+test_cont_adapter()
+{
+	{
+		std::vector<char> vec;
+		mpp::encode(vec, 10, "abc", std::forward_as_tuple(false, 1.));
+		int res1 = 0;
+		std::string res2;
+		bool res3 = true;
+		double res4 = 2.;
+		mpp::decode(vec.data(), res1, res2, std::tie(res3, res4));
+		fail_unless(res1 == 10);
+		fail_unless(res2 == "abc");
+		fail_unless(res3 == false);
+		fail_unless(res4 == 1.);
+	}
+	{
+		char buf[16];
+		char *p = buf;
+		mpp::encode(p, 10, "abc", std::forward_as_tuple(false, 1.));
+		int res1 = 0;
+		std::string res2;
+		bool res3 = true;
+		double res4 = 2.;
+		p = buf;
+		mpp::decode(p, res1, res2, std::tie(res3, res4));
+		fail_unless(res1 == 10);
+		fail_unless(res2 == "abc");
+		fail_unless(res3 == false);
+		fail_unless(res4 == 1.);
+	}
+}
+
 int main()
 {
 	test_under_ints();
@@ -1334,4 +1367,5 @@ int main()
 	test_optional();
 	test_raw();
 	test_variant();
+	test_cont_adapter();
 }

--- a/test/EncDecTest.cpp
+++ b/test/EncDecTest.cpp
@@ -164,15 +164,11 @@ test_type_visual()
 {
 	TEST_INIT(0);
 	using namespace mpp;
-	std::cout << compact::MP_ARR << " "
-		  << compact::MP_MAP << " "
-		  << compact::MP_EXT << "\n";
+	std::cout << MP_ARR << " " << MP_MAP << " " << MP_EXT << "\n";
 
 	std::cout << "(" << family_sequence<>{} << ") "
-		  << "(" << family_sequence<compact::MP_NIL>{} << ") "
-		  << "(" << family_sequence<compact::MP_INT,
-					    compact::MP_FLT,
-					    compact::MP_NIL>{} << ")\n";
+		  << "(" << family_sequence<MP_NIL>{} << ") "
+		  << "(" << family_sequence<MP_INT, MP_FLT, MP_NIL>{} << ")\n";
 }
 
 enum E1 {

--- a/test/RulesUnitTest.cpp
+++ b/test/RulesUnitTest.cpp
@@ -37,7 +37,7 @@
 #include "Utils/Helpers.hpp"
 
 namespace test {
-using fis_t = std::make_index_sequence<mpp::compact::MP_END>;
+using fis_t = std::make_index_sequence<mpp::MP_END>;
 
 template <class R, class _ = void>
 struct has_simplex : std::false_type {};
@@ -86,7 +86,7 @@ constexpr bool rule_has_tag_v =
 template <uint8_t TAG, size_t FAMILY, size_t ...MORE>
 constexpr auto rule_by_tag_h(std::index_sequence<FAMILY, MORE...>)
 {
-	constexpr mpp::compact::Family family{FAMILY};
+	constexpr mpp::Family family{FAMILY};
 	using rule_t = mpp::rule_by_family_t<family>;
 	if constexpr (rule_has_tag_v<rule_t, TAG>) {
 		return rule_t{};
@@ -101,7 +101,7 @@ using rule_by_tag_t = decltype(rule_by_tag_h<TAG>(test::fis_t{}));
 
 } // namespace test
 
-template <mpp::compact::Family FAMILY>
+template <mpp::Family FAMILY>
 void
 check_family_rule()
 {
@@ -112,14 +112,14 @@ check_family_rule()
 	if constexpr (Rule_t::has_simplex)
 		static_assert(Rule_t::simplex_value_range.first == 0 ||
 			      (Rule_t::simplex_value_range.first < 0 &&
-			       FAMILY == mpp::compact::MP_INT));
+			       FAMILY == mpp::MP_INT));
 }
 
 template <size_t ...FAMILY>
 void
 check_family_rule(std::index_sequence<FAMILY...>)
 {
-	(check_family_rule<static_cast<mpp::compact::Family>(FAMILY)>(), ...);
+	(check_family_rule<static_cast<mpp::Family>(FAMILY)>(), ...);
 }
 
 void
@@ -134,8 +134,8 @@ test_basic()
 	// Some selective checks.
 	static_assert(std::is_same_v<std::tuple<bool>, BoolRule::types>);
 	static_assert(std::is_same_v<std::tuple<uint64_t, int64_t>, IntRule::types>);
-	static_assert(NilRule::family == compact::MP_NIL);
-	static_assert(BinRule::family == compact::MP_BIN);
+	static_assert(NilRule::family == MP_NIL);
+	static_assert(BinRule::family == MP_BIN);
 	static_assert(IgnrRule::has_data == false);
 	static_assert(StrRule::has_data == true);
 	static_assert(BinRule::has_data == true);
@@ -281,7 +281,7 @@ template <class T>
 constexpr std::array<size_t, std::tuple_size_v<T>> tuple_sizes =
 	tuple_sizes_h<T>(std::make_index_sequence<std::tuple_size_v<T>>{});
 
-template <mpp::compact::Family FAMILY>
+template <mpp::Family FAMILY>
 void collectByType(FullInfo& infos)
 {
 	using Rule = mpp::rule_by_family_t<FAMILY>;
@@ -323,7 +323,7 @@ template <size_t ...FAMILY>
 FullInfo collectByType(std::index_sequence<FAMILY...>)
 {
 	FullInfo infos;
-	(collectByType<static_cast<mpp::compact::Family>(FAMILY)>(infos), ...);
+	(collectByType<static_cast<mpp::Family>(FAMILY)>(infos), ...);
 	return infos;
 }
 


### PR DESCRIPTION
mpp: implement container adapter

Previously encode/decode expected the first argument (cont) to
be tnt::Buffer of something with the same API.

This commit introduces contaier adapter, so it is allowed now to
encode to standard contiguous container (std::vector etc) and
encode/decode just by pointer to data.

Fix decode headers while we are here.

Fix README.md.

Make some other simplifications and improvements.
