### PR TITLE
client: fix `result` argument of `wait`

### DIFF
--- a/src/Client/Connection.hpp
+++ b/src/Client/Connection.hpp
@@ -230,8 +230,7 @@ public:
 
 	template<class B, class N>
 	friend
-	enum DecodeStatus processResponse(Connection<B, N> &conn,
-					  Response<B> *result);
+	enum DecodeStatus processResponse(Connection<B, N> &conn, int req_sync, Response<B> *result);
 
 	template<class B, class N>
 	friend
@@ -530,8 +529,7 @@ inputBufGC(Connection<BUFFER, NetProvider> &conn)
 
 template<class BUFFER, class NetProvider>
 DecodeStatus
-processResponse(Connection<BUFFER, NetProvider> &conn,
-		Response<BUFFER> *result)
+processResponse(Connection<BUFFER, NetProvider> &conn, int req_sync, Response<BUFFER> *result)
 {
 	//Decode response. In case of success - fill in feature map
 	//and adjust end-of-decoded data pointer. Call GC if needed.
@@ -563,7 +561,7 @@ processResponse(Connection<BUFFER, NetProvider> &conn,
 	}
 	LOG_DEBUG("Header: sync=", response.header.sync, ", code=",
 		  response.header.code, ", schema=", response.header.schema_id);
-	if (result != nullptr) {
+	if (result != nullptr && response.header.sync == req_sync) {
 		*result = std::move(response);
 	} else {
 		conn.impl->futures.insert({response.header.sync,

--- a/src/Client/Connector.hpp
+++ b/src/Client/Connector.hpp
@@ -97,7 +97,7 @@ private:
 	 * Returns -1 in the case of any error, 0 on success.
 	 */
 	int connectionDecodeResponses(Connection<BUFFER, NetProvider> &conn,
-				      Response<BUFFER> *result);
+				      Response<BUFFER> *result = nullptr);
 
 private:
 	NetProvider m_NetProvider;
@@ -266,7 +266,7 @@ Connector<BUFFER, NetProvider>::waitAll(Connection<BUFFER, NetProvider> &conn,
 				      strerror(errno), errno);
 			return -1;
 		}
-		if (connectionDecodeResponses(conn, static_cast<Response<BUFFER>*>(nullptr)) != 0)
+		if (connectionDecodeResponses(conn) != 0)
 			return -1;
 		bool finish = true;
 		for (size_t i = last_not_ready; i < futures.size(); ++i) {
@@ -306,7 +306,7 @@ Connector<BUFFER, NetProvider>::waitAny(int timeout)
 	}
 	Connection<BUFFER, NetProvider> conn = *m_ReadyToDecode.begin();
 	assert(hasDataToDecode(conn));
-	if (connectionDecodeResponses(conn, static_cast<Response<BUFFER>*>(nullptr)) != 0)
+	if (connectionDecodeResponses(conn) != 0)
 		return std::nullopt;
 	return conn;
 }
@@ -325,7 +325,7 @@ Connector<BUFFER, NetProvider>::waitCount(Connection<BUFFER, NetProvider> &conn,
 				      strerror(errno), errno);
 			return -1;
 		}
-		if (connectionDecodeResponses(conn, static_cast<Response<BUFFER>*>(nullptr)) != 0)
+		if (connectionDecodeResponses(conn) != 0)
 			return -1;
 		if ((conn.getFutureCount() - ready_futures) >= future_count)
 			return 0;

--- a/test/ClientTest.cpp
+++ b/test/ClientTest.cpp
@@ -1280,6 +1280,29 @@ test_wait(Connector<BUFFER, NetProvider> &client)
 	client.close(conn2);
 	client.close(conn3);
 
+	TEST_CASE("wait with argument result");
+	f = conn.ping();
+	fail_unless(!conn.futureIsReady(f));
+	Response<BUFFER> result;
+	fail_unless(client.wait(conn, f, WAIT_TIMEOUT, &result) == 0);
+	/* The result was consumed, so the future is not ready. */
+	fail_unless(!conn.futureIsReady(f));
+	/* The future is actually request sync - check if the result is valid. */
+	fail_unless(result.header.sync == static_cast<int>(f));
+	fail_unless(result.header.code == 0);
+
+	TEST_CASE("wait with argument result for decoded future");
+	f = conn.ping();
+	fail_unless(!conn.futureIsReady(f));
+	fail_unless(client.wait(conn, f, WAIT_TIMEOUT) == 0);
+	fail_unless(conn.futureIsReady(f));
+	fail_unless(client.wait(conn, f, WAIT_TIMEOUT, &result) == 0);
+	/* The result was consumed, so the future is not ready. */
+	fail_unless(!conn.futureIsReady(f));
+	/* The future is actually request sync - check if the result is valid. */
+	fail_unless(result.header.sync == static_cast<int>(f));
+	fail_unless(result.header.code == 0);
+
 	client.close(conn);
 }
 

--- a/test/ClientTest.cpp
+++ b/test/ClientTest.cpp
@@ -1303,6 +1303,27 @@ test_wait(Connector<BUFFER, NetProvider> &client)
 	fail_unless(result.header.sync == static_cast<int>(f));
 	fail_unless(result.header.code == 0);
 
+	TEST_CASE("wait with argument result - several requests");
+	/* Obtain in direct order. */
+	f1 = conn.ping();
+	f2 = conn.ping();
+	fail_unless(client.wait(conn, f1, WAIT_TIMEOUT, &result) == 0);
+	fail_unless(result.header.sync == static_cast<int>(f1));
+	fail_unless(result.header.code == 0);
+	fail_unless(client.wait(conn, f2, WAIT_TIMEOUT, &result) == 0);
+	fail_unless(result.header.sync == static_cast<int>(f2));
+	fail_unless(result.header.code == 0);
+
+	/* Obtain in reversed order. */
+	f1 = conn.ping();
+	f2 = conn.ping();
+	fail_unless(client.wait(conn, f2, WAIT_TIMEOUT, &result) == 0);
+	fail_unless(result.header.sync == static_cast<int>(f2));
+	fail_unless(result.header.code == 0);
+	fail_unless(client.wait(conn, f1, WAIT_TIMEOUT, &result) == 0);
+	fail_unless(result.header.sync == static_cast<int>(f1));
+	fail_unless(result.header.code == 0);
+
 	client.close(conn);
 }
 


### PR DESCRIPTION
The argument was completely broken - the commit fixes it.
Along the way, fixed a crash when a decoded future appeared in `m_ReadyToDecode`. See the commits for details.

Closes #112
Closes https://github.com/tarantool/tntcxx/issues/124