### PR TITLE
Wait methods fixes

### DIFF
--- a/src/Client/Connector.hpp
+++ b/src/Client/Connector.hpp
@@ -345,7 +345,10 @@ Connector<BUFFER, NetProvider>::waitAny(int timeout)
 	Timer timer{timeout};
 	timer.start();
 	while (m_ReadyToDecode.empty()) {
-		m_NetProvider.wait(timer.timeLeft());
+		if (m_NetProvider.wait(timer.timeLeft()) != 0) {
+			LOG_ERROR("Failed to poll connections: ", strerror(errno));
+			return std::nullopt;
+		}
 		if (timer.isExpired())
 			break;
 	}

--- a/test/ClientTest.cpp
+++ b/test/ClientTest.cpp
@@ -1324,6 +1324,28 @@ test_wait(Connector<BUFFER, NetProvider> &client)
 	fail_unless(result.header.sync == static_cast<int>(f1));
 	fail_unless(result.header.code == 0);
 
+	TEST_CASE("wait method check future readiness before waiting (gh-133");
+	f = conn.ping();
+	fail_unless(client.wait(conn, f, WAIT_TIMEOUT) == 0);
+	fail_unless(client.wait(conn, f) == 0);
+	conn.getResponse(f);
+	f = conn.ping();
+	fail_unless(client.wait(conn, f, WAIT_TIMEOUT) == 0);
+	fail_unless(client.waitAll(conn, {f}) == 0);
+	conn.getResponse(f);
+	f = conn.ping();
+	fail_unless(client.wait(conn, f, WAIT_TIMEOUT) == 0);
+	/* FIXME(gh-143): test solely that we check future readiness before waiting. */
+	fail_unless(client.waitCount(conn, 0) == 0);
+	conn.getResponse(f);
+	/* FIXME(gh-132): waitAny does not check connections for ready futures. */
+#if 0
+	f = conn.ping();
+	fail_unless(client.wait(conn, f, WAIT_TIMEOUT) == 0);
+	fail_unless(client.waitAny(conn).has_value());
+	conn.getResponse(f);
+#endif
+
 	client.close(conn);
 }
 


### PR DESCRIPTION
This patchset fixes some bugs with the Connector `wait*` methods.

Closes #121
closes #133